### PR TITLE
Add syntax sugar for basis translations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ add_library(qwc STATIC qwerty/ast.cpp
                        qwerty/qpu_kernel.cpp
                        qwerty/ast_visitor/flag_immat.cpp
                        qwerty/ast_visitor/canonicalize.cpp
+                       qwerty/ast_visitor/desugar.cpp
                        qwerty/ast_visitor/graphviz.cpp
                        qwerty/ast_visitor/find_instants.cpp
                        qwerty/ast_visitor/eval_dimvar_exprs.cpp

--- a/examples/wip/basis_sugar.py
+++ b/examples/wip/basis_sugar.py
@@ -1,0 +1,13 @@
+from qwerty import *
+
+# Proof-of-concept for language syntax sugar.
+
+@qpu
+def sweet() -> bit:
+    # return 'p' | {'p', 'm'} >> {'0', '1'} | measure
+    return 'p' | {'p' >> '0', 'm' >> '1'} | measure
+    # All of the following should cause typechecking to fail: 
+    # return '0' | {{'0', '1'} >> {'p', 'm'}, {'p', 'm'} >> {'i', 'j'}} | measure
+    # return '0' | {{'0', '1'} >> {'p', 'm'}, 'p' >> 'i'} | measure
+
+print(sweet())

--- a/qwerty/ast.hpp
+++ b/qwerty/ast.hpp
@@ -2895,13 +2895,11 @@ struct Kernel : ASTNode, HybridObj {
         }
         // Desugar -- want this to be distinct from canonicalization
         // since we seem to want to type-check after canonicalizing.
-        // This limits which transformations can avoid typechecking.
-        /*
+        // This limits which transformations can avoid typechecking
         {
             DesugarVisitor desugarVisitor;
             walk(desugarVisitor);
         }
-        */
         // Type check #1
         {
             V typeCheckVisitor;

--- a/qwerty/ast.hpp
+++ b/qwerty/ast.hpp
@@ -2893,6 +2893,15 @@ struct Kernel : ASTNode, HybridObj {
             EvalDimVarExprVisitor evalVisitor(dimvar_values);
             walk(evalVisitor);
         }
+        // Desugar -- want this to be distinct from canonicalization
+        // since we seem to want to type-check after canonicalizing.
+        // This limits which transformations can avoid typechecking.
+        /*
+        {
+            DesugarVisitor desugarVisitor;
+            walk(desugarVisitor);
+        }
+        */
         // Type check #1
         {
             V typeCheckVisitor;
@@ -3118,6 +3127,7 @@ struct QpuKernel : Kernel {
         walk(dynBasisVisitor);
     }
     virtual void runASTVisitorPipeline() override {
+        // Here?
         _runASTVisitorPipeline<QpuTypeCheckVisitor>();
     }
     virtual std::unique_ptr<ASTNode> copy() const override {

--- a/qwerty/ast_visitor.hpp
+++ b/qwerty/ast_visitor.hpp
@@ -315,6 +315,60 @@ struct ClassicalTypeCheckVisitor : BaseTypeCheckVisitor {
     virtual bool visit(ASTVisitContext &ctx, Slice &slice) override;
 };
 
+// Rewrites AST w/o syntax sugar. While technically a form of canonicalization,
+// this visit pass is made distinct to ensure only a very small set of transformations
+// can avoid type-checking.
+struct DesugarVisitor : ASTVisitor {
+    virtual Traversal traversal() override { return Traversal::PREPOSTORDER; }
+    virtual void init(ASTNode &root) override {}
+
+    virtual bool visit(ASTVisitContext &ctx, Assign &assign) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, DestructAssign &assign) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Return &ret) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Kernel &kernel) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Variable &var) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Slice &slice) override { return true; }
+    // @qpu nodes
+    virtual bool visit(ASTVisitContext &ctx, Adjoint &adj) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Prepare &prep) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Lift &lift) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, EmbedClassical &embed) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Pipe &pipe) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Instantiate &inst) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Repeat &repeat) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, RepeatTensor &reptens) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Pred &pred) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BiTensor &bitensor) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BroadcastTensor &broadtensor) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, QubitLiteral &lit) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Phase &phase) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, FloatLiteral &float_) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, FloatNeg &neg) override { return true; };
+    virtual bool visit(ASTVisitContext &ctx, FloatBinaryOp &bin) override { return true;}
+    virtual bool visit(ASTVisitContext &ctx, FloatDimVarExpr &fdve) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, TupleLiteral &tuple) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BuiltinBasis &std) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Identity &id) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BasisTranslation &trans) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Discard &discard) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Measure &measure) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Project &proj) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Flip &flip) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Rotate &rot) override { return true; }
+    // This actually does something!
+    virtual bool visit(ASTVisitContext &ctx, BasisLiteral &lit) override;
+    virtual bool visit(ASTVisitContext &ctx, SuperposLiteral &lit) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, Conditional &cond) override { return true; }
+    // @classical nodes
+    virtual bool visit(ASTVisitContext &ctx, BitUnaryOp &unOp) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BitBinaryOp &binOp) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BitReduceOp &reduceOp) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BitConcat &concat) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BitRepeat &concat) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, ModMulOp &mulOp) override { return true; }
+    virtual bool visit(ASTVisitContext &ctx, BitLiteral &bitLit) override { return true; }
+};
+
 // Simplifies the AST. Performs some basic optimizations (Section 4.2 of the
 // CGO paper) and also replaces some semi-redundant nodes. For example,
 // BroadcastTensors and LiftBits do not survive this visitor.

--- a/qwerty/ast_visitor/desugar.cpp
+++ b/qwerty/ast_visitor/desugar.cpp
@@ -1,0 +1,40 @@
+#include "ast.hpp"
+#include "ast_visitor.hpp"
+
+// Rewrites basis literals of the form {a >> b, c >> d, ...} into {a, c, ...} >> {b, d, ...}
+// I'm open to treating this as "canonicalization" if you don't mind it running
+// *before* typechecking, but my intuition tells me it's a bad idea.
+bool DesugarVisitor::visit(ASTVisitContext &ctx, BasisLiteral &lit) {
+    for (auto const &elt : lit.elts) {
+        // Our types don't implement this.
+        if (!dynamic_cast<BasisTranslation *>(elt.get())) {
+            // Forward this to type-checking so it can admit literals 
+            // of the form {'qbl1', 'qbl2', ...} or complain appropriately
+            return true;
+        }
+    }
+
+    std::vector<std::unique_ptr<ASTNode>> input_basis{};
+    input_basis.reserve(lit.elts.size());
+    std::vector<std::unique_ptr<ASTNode>> output_basis{};
+    output_basis.reserve(lit.elts.size());
+
+    for (auto const &elt : lit.elts) {
+        // Already know it's all BasisTranslation, static cast is safe.
+        BasisTranslation *btrans = static_cast<BasisTranslation *>(elt.get());
+        input_basis.push_back(std::move(btrans->basis_in));
+        output_basis.push_back(std::move(btrans->basis_out));
+    }
+
+    // Move everything everywhere everywhen
+    // FIXME: Don't know how we handle debug info...
+    std::unique_ptr<BasisTranslation> new_btrans =
+        std::make_unique<BasisTranslation>(std::move(lit.dbg->copy()),
+                                           std::make_unique<BasisLiteral>(std::move(lit.dbg->copy()),
+                                                                          std::move(input_basis)),
+                                           std::make_unique<BasisLiteral>(std::move(lit.dbg->copy()),
+                                                                          std::move(output_basis)));
+
+    ctx.ptr = std::move(new_btrans);
+    return false;
+}

--- a/test/integration_tests/tests/basis_sugar.py
+++ b/test/integration_tests/tests/basis_sugar.py
@@ -1,0 +1,13 @@
+from qwerty import *
+
+# Proof-of-concept for language syntax sugar.
+
+@qpu
+def sweet() -> bit:
+    # return 'p' | {'p', 'm'} >> {'0', '1'} | measure
+    return 'p' | {'p' >> '0', 'm' >> '1'} | measure
+    # All of the following should cause typechecking to fail: 
+    # return '0' | {{'0', '1'} >> {'p', 'm'}, {'p', 'm'} >> {'i', 'j'}} | measure
+    # return '0' | {{'0', '1'} >> {'p', 'm'}, 'p' >> 'i'} | measure
+
+print(sweet())


### PR DESCRIPTION
This PR adds support for writing basis translations in a way that might be more immediately intuitive to students:

{bv1 >> bvp1, bv2 >> bvp2, ...}
----------------------------------------------
{bv1, bv2, ...} >> {bvp1, bvp2, ...}

All existing tests pass and I've included the program I've used to test it. I was originally going to upgrade this program into an "integration test" but I saw there was C++ code that validates AST canonicalization directly, so I figured I would add one after making this PR.

The weird branch name is to deal with version control headache.

Here's a little Haskell trivia I thought of while implementing this: this transformation has the form of "applicative" notably the <*> operator:

(<*>) :: Applicative f => f (a -> b) -> f a -> f b

Here, f = {}, (a->b) = >>, a = BasisLiteral, b = BasisLiteral. We're basically doing (<*> {bvi >> bvj}) = {bvi} >> {bvj}
