### PR TITLE
Enforce linearity in MLIR verifier.

### DIFF
--- a/qwerty/util.hpp
+++ b/qwerty/util.hpp
@@ -17,6 +17,4 @@
 // Rz(theta))
 #define ATOL 1e-12
 
-// Span-checking logic
-
 #endif

--- a/qwerty/util.hpp
+++ b/qwerty/util.hpp
@@ -17,4 +17,6 @@
 // Rz(theta))
 #define ATOL 1e-12
 
+// Span-checking logic
+
 #endif

--- a/qwerty_mlir/lib/Qwerty/IR/QwertyOps.cpp
+++ b/qwerty_mlir/lib/Qwerty/IR/QwertyOps.cpp
@@ -1988,14 +1988,6 @@ mlir::LogicalResult QBundlePackOp::inferReturnTypes(
 }
 
 mlir::LogicalResult QBundlePackOp::verify() {
-#if RETAIN_OLD_VERIFIERS
-    auto bundle = getQbundle();
-
-    if (!(bundle.hasOneUse() || linearCheckForManyUses(bundle))) {
-        return this->emitOpError("QBundlePackOp: ")
-            << "Bundle qubits is not linear with this IR instruction";
-    }
-#endif
     return mlir::success();
 }
 
@@ -2028,20 +2020,6 @@ mlir::LogicalResult QBundleUnpackOp::inferReturnTypes(
 }
 
 mlir::LogicalResult QBundleUnpackOp::verify() {
-#if RETAIN_OLD_VERIFIERS
-    auto qubits = getQubits();
-
-    for (auto indexedResult : llvm::enumerate(qubits)) {
-        mlir::Value qubit = indexedResult.value();
-
-        if (!(qubit.hasOneUse() || linearCheckForManyUses(qubit))) {
-            return this->emitOpError("QBundleUnpackOp: ")
-                << "Qubit(" << indexedResult.index()
-                << ") is not linear with this IR instruction (gate)";
-        }
-    }
-#endif
-
     return mlir::success();
 }
 
@@ -2208,15 +2186,6 @@ void QBundleDiscardZeroOp::buildAdjoint(
 }
 
 mlir::LogicalResult QBundleIdentityOp::verify() {
-#if RETAIN_OLD_VERFIERS
-    auto bundle = getQbundleOut();
-
-    if (!(bundle.hasOneUse() || linearCheckForManyUses(bundle))) {
-        return this->emitOpError("QBundleIdentityOp: ")
-            << "Bundle qubits is not linear with this IR instruction";
-    }
-#endif
-
     return mlir::success();
 }
 
@@ -2244,15 +2213,6 @@ mlir::LogicalResult QBundlePhaseOp::inferReturnTypes(
 }
 
 mlir::LogicalResult QBundlePhaseOp::verify() {
-#if RETAIN_OLD_VERIFIERS
-    auto bundle = getQbundleOut();
-
-    if (!(bundle.hasOneUse() || linearCheckForManyUses(bundle))) {
-        return this->emitOpError("QBundlePhaseOp: ")
-            << "Bundle qubits is not linear with this IR instruction";
-    }
-#endif
-
     return mlir::success();
 }
 
@@ -2363,9 +2323,6 @@ mlir::LogicalResult QBundleBasisTranslationOp::verify() {
     uint64_t basis_in_dim = getBasisIn().getDim();
     uint64_t qbundle_dim = getQbundleIn().getType().getDim();
     uint64_t basis_out_dim = getBasisOut().getDim();
-#if RETAIN_OLD_VERIFIERS
-    auto bundle = getQbundleOut();
-#endif
 
     if (basis_in_dim != qbundle_dim) {
         return this->emitOpError("QBundleBasisTranslationOp: ")
@@ -2384,13 +2341,6 @@ mlir::LogicalResult QBundleBasisTranslationOp::verify() {
     if (n_total_phases != getBasisPhases().size()) {
         return emitOpError("Mismatch in number of basis phases");
     }
-
-#if RETAIN_OLD_VERIFIERS
-    if (!(bundle.hasOneUse() || linearCheckForManyUses(bundle))) {
-        return this->emitOpError("QBundleBasisTranslationOp: ")
-            << "Bundle qubits is not linear with this IR instruction";
-    }
-#endif
 
     return mlir::success();
 }
@@ -2563,14 +2513,6 @@ mlir::LogicalResult QBundleFlipOp::verify() {
         return emitOpError("Mismatch in number of basis phases");
     }
 
-#if RETAIN_OLD_VERIFIERS
-    auto bundle_out = getQbundleOut();
-    if (!(bundle_out.hasOneUse() || linearCheckForManyUses(bundle_out))) {
-        return emitOpError("QBundleFlipOp: ")
-            << "Bundle qubits is not linear with this IR instruction";
-    }
-#endif
-
     return mlir::success();
 }
 
@@ -2689,14 +2631,6 @@ mlir::LogicalResult QBundleRotateOp::verify() {
         return this->emitOpError("Rotate basis must fully span");
     }
 
-
-#if RETAIN_OLD_VERIFIERS
-    auto bundle_out = getQbundleOut();
-    if (!(bundle_out.hasOneUse() || linearCheckForManyUses(bundle_out))) {
-        return this->emitOpError("QBundleRotateOp: ")
-            << "Bundle qubits is not linear with this IR instruction";
-    }
-#endif
 
     return mlir::success();
 }

--- a/qwerty_mlir/lib/Qwerty/IR/QwertyOps.cpp
+++ b/qwerty_mlir/lib/Qwerty/IR/QwertyOps.cpp
@@ -855,9 +855,12 @@ mlir::LogicalResult FuncOp::verifyBody() {
             // OpResult <: Value
             for (auto [idx, result] : llvm::enumerate(op.getResults())) {
                 // NOTE: Presently, these are the only two linear types in the IR.
+                // What could also be nicer is if we pointed to the usage locations.
+                // Actually, that doesn't sound too hard, since that's exactly what `linearCheckForManyUses`
+                // does.
                 if (mlir::isa<qwerty::QBundleType>(result.getType())) {
                     if (!(result.hasOneUse() || linearCheckForManyUses(result))) {
-                        return op.emitOpError("-- Bundle qubits is not linear with this IR instruction");
+                        return op.emitOpError("Bundle qubits is not linear with this IR instruction");
                     }
                 }
 

--- a/qwerty_mlir/lib/Qwerty/IR/QwertyOps.cpp
+++ b/qwerty_mlir/lib/Qwerty/IR/QwertyOps.cpp
@@ -848,11 +848,10 @@ mlir::LogicalResult FuncOp::verifyBody() {
     }
 
     // Now we just check if all values that need to be linear are, in fact, linear.
-    for (mlir::Block& le_bloque : getBody()) {
-        // We *do* want to consider all MLIR ops because
-        // we want to check the results of `scf.if` and any future additions.
-        for (mlir::Operation& op : le_bloque.getOperations()) {
-            // OpResult <: Value
+    for (mlir::Block& b : getBody()) {
+        // We *do* want to consider all MLIR ops so we can verify ops that 
+        // come from dialects we don't own!
+        for (mlir::Operation& op : b.getOperations()) {
             for (auto [idx, result] : llvm::enumerate(op.getResults())) {
                 // NOTE: Presently, these are the only two linear types in the IR.
                 // What could also be nicer is if we pointed to the usage locations.

--- a/test/test_qwerty_mlir/Qwerty/IR/verifier.mlir
+++ b/test/test_qwerty_mlir/Qwerty/IR/verifier.mlir
@@ -1,0 +1,54 @@
+// RUN: qwerty-opt %s --split-input-file --verify-diagnostics
+
+module {
+  qwerty.func @sciff_iff_0[]() irrev-> !qwerty<bitbundle[1]> {
+    %0 = qwerty.qbprep Z<PLUS>[1] : () -> !qwerty<qbundle[1]>
+    %1 = qwerty.qbprep X<PLUS>[1] : () -> !qwerty<qbundle[1]>
+    %2 = qwerty.qbmeas %0 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    %3 = qwerty.bitunpack %2 : (!qwerty<bitbundle[1]>) -> i1
+    // expected-error@+1 {{Bundle qubits is not linear with this IR instruction}}
+    %4 = scf.if %3 -> (!qwerty<qbundle[1]>) {
+      %7 = qwerty.qbtrans %1 by {std: X[1]} >> {std: Z[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+      scf.yield %7 : !qwerty<qbundle[1]>
+    } else {
+      %7 = qwerty.qbtrans %1 by {std: X[1]} >> {std: Y[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+      scf.yield %7 : !qwerty<qbundle[1]>
+    }
+    %5 = qwerty.qbmeas %4 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    %6 = qwerty.qbmeas %4 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    qwerty.return %5 : !qwerty<bitbundle[1]>
+  }
+}
+
+// -----
+
+module {
+  qwerty.func @no_cloning_0[]() irrev-> !qwerty<bitbundle[1]> {
+    %0 = qwerty.qbprep X<PLUS>[1] : () -> !qwerty<qbundle[1]>
+    %1 = qwerty.qbmeas %0 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    qwerty.return %1 : !qwerty<bitbundle[1]>
+  }
+  qwerty.func @unpack_this_1[]() irrev-> !qwerty<bitbundle[4]> {
+    %0 = qwerty.qbprep Z<PLUS>[2] : () -> !qwerty<qbundle[2]>
+    %1 = qwerty.qbprep X<PLUS>[2] : () -> !qwerty<qbundle[2]>
+    // expected-error@+1 {{Qubit(0) is not linear with this IR instruction (gate)}}
+    %2:2 = qwerty.qbunpack %0 : (!qwerty<qbundle[2]>) -> (!qcirc.qubit, !qcirc.qubit)
+    %3:2 = qwerty.qbunpack %1 : (!qwerty<qbundle[2]>) -> (!qcirc.qubit, !qcirc.qubit)
+    %4 = qwerty.qbpack(%2#0) : (!qcirc.qubit) -> !qwerty<qbundle[1]>
+    %5 = qwerty.qbpack(%2#1) : (!qcirc.qubit) -> !qwerty<qbundle[1]>
+    %6 = qwerty.qbtrans %4 by {std: Z[1]} >> {std: X[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+    %7 = qwerty.qbtrans %5 by {std: Z[1]} >> {std: X[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+    %8 = qwerty.qbunpack %6 : (!qwerty<qbundle[1]>) -> !qcirc.qubit
+    %9 = qwerty.qbunpack %7 : (!qwerty<qbundle[1]>) -> !qcirc.qubit
+    %10 = qwerty.qbpack(%3#0) : (!qcirc.qubit) -> !qwerty<qbundle[1]>
+    %11 = qwerty.qbpack(%3#1) : (!qcirc.qubit) -> !qwerty<qbundle[1]>
+    %12 = qwerty.qbtrans %10 by {std: X[1]} >> {std: Z[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+    %13 = qwerty.qbtrans %11 by {std: X[1]} >> {std: Z[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+    %14 = qwerty.qbunpack %12 : (!qwerty<qbundle[1]>) -> !qcirc.qubit
+    %15 = qwerty.qbunpack %13 : (!qwerty<qbundle[1]>) -> !qcirc.qubit
+    %16 = qwerty.qbpack(%8, %9, %14, %15) : (!qcirc.qubit, !qcirc.qubit, !qcirc.qubit, !qcirc.qubit) -> !qwerty<qbundle[4]>
+    %17 = qwerty.qbmeas %16 by {std: Z[4]} : !qwerty<qbundle[4]> -> !qwerty<bitbundle[4]>
+    %18 = qwerty.qbpack(%2#0) : (!qcirc.qubit) -> !qwerty<qbundle[1]>
+    qwerty.return %17 : !qwerty<bitbundle[4]>
+  }
+}

--- a/test/test_qwerty_mlir/Qwerty/IR/verifier.mlir
+++ b/test/test_qwerty_mlir/Qwerty/IR/verifier.mlir
@@ -52,3 +52,68 @@ module {
     qwerty.return %17 : !qwerty<bitbundle[4]>
   }
 }
+
+// -----
+
+module {
+  qwerty.func @sciff_iff_0[]() irrev-> !qwerty<bitbundle[1]> {
+    %0 = qwerty.qbprep Z<PLUS>[1] : () -> !qwerty<qbundle[1]>
+    // expected-error@+1 {{Bundle qubits is not linear with this IR instruction}}
+    %1 = qwerty.qbprep X<PLUS>[1] : () -> !qwerty<qbundle[1]>
+    %2 = qwerty.qbmeas %0 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    %3 = qwerty.bitunpack %2 : (!qwerty<bitbundle[1]>) -> i1
+    %4 = scf.if %3 -> (!qwerty<qbundle[1]>) {
+      %7 = qwerty.qbtrans %1 by {std: X[1]} >> {std: Z[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+      %8 = qwerty.qbtrans %1 by {std: X[1]} >> {std: Z[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+      scf.yield %7 : !qwerty<qbundle[1]>
+    } else {
+      %7 = qwerty.qbtrans %1 by {std: X[1]} >> {std: Y[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+      scf.yield %7 : !qwerty<qbundle[1]>
+    }
+    %5 = qwerty.qbmeas %4 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    %6 = qwerty.qbmeas %4 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    qwerty.return %5 : !qwerty<bitbundle[1]>
+  }
+}
+
+// -----
+
+module {
+  qwerty.func @sciff_iff_0[]() irrev-> !qwerty<bitbundle[1]> {
+    %0 = qwerty.qbprep Z<PLUS>[1] : () -> !qwerty<qbundle[1]>
+    %1 = qwerty.qbprep X<PLUS>[1] : () -> !qwerty<qbundle[1]>
+    %2 = qwerty.qbmeas %0 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    %3 = qwerty.bitunpack %2 : (!qwerty<bitbundle[1]>) -> i1
+    // expected-error@+1 {{Bundle qubits is not linear with this IR instruction}}
+    %4 = scf.if %3 -> (!qwerty<qbundle[1]>) {
+      %12 = qwerty.qbtrans %1 by {std: X[1]} >> {std: Z[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+      scf.yield %12 : !qwerty<qbundle[1]>
+    } else {
+      %12 = qwerty.qbtrans %1 by {std: X[1]} >> {std: Y[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+      scf.yield %12 : !qwerty<qbundle[1]>
+    }
+    %5 = qwerty.qbprep Z<MINUS>[1] : () -> !qwerty<qbundle[1]>
+    %6 = qwerty.qbmeas %5 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    %7 = qwerty.qbprep X<MINUS>[1] : () -> !qwerty<qbundle[1]>
+    %8 = qwerty.qbmeas %7 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    %9 = qwerty.bitunpack %6 : (!qwerty<bitbundle[1]>) -> i1
+    %10 = scf.if %9 -> (!qwerty<qbundle[1]>) {
+      %12 = qwerty.qbtrans %4 by {std: Y[1]} >> {std: Z[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+      scf.yield %12 : !qwerty<qbundle[1]>
+    } else {
+      %12 = qwerty.bitunpack %8 : (!qwerty<bitbundle[1]>) -> i1
+      %13 = scf.if %12 -> (!qwerty<qbundle[1]>) {
+        %14 = qwerty.qbtrans %4 by {std: Z[1]} >> {std: Y[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+        scf.yield %14 : !qwerty<qbundle[1]>
+      } else {
+        %14 = qwerty.qbtrans %4 by {std: X[1]} >> {std: Y[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+        %15 = qwerty.qbtrans %4 by {std: X[1]} >> {std: Y[1]} : (!qwerty<qbundle[1]>) -> !qwerty<qbundle[1]>
+        scf.yield %14 : !qwerty<qbundle[1]>
+      }
+      scf.yield %13 : !qwerty<qbundle[1]>
+    }
+    %11 = qwerty.qbmeas %10 by {std: Z[1]} : !qwerty<qbundle[1]> -> !qwerty<bitbundle[1]>
+    qwerty.return %11 : !qwerty<bitbundle[1]>
+  }
+}
+


### PR DESCRIPTION
Addresses #9 in the general case. Moves linearity-checking logic to apply to all `mlir::Value`s in a `qwerty.func`'s body that have linear types. This check also correctly handles regions within other regions, as verified by the included tests.