### PR TITLE
Lower arith select ops + integration test + QwertyOps cleanup

### DIFF
--- a/qwerty_mlir/lib/Qwerty/IR/QwertyOps.cpp
+++ b/qwerty_mlir/lib/Qwerty/IR/QwertyOps.cpp
@@ -256,17 +256,21 @@ struct CallIndirectConst : public mlir::OpRewritePattern<qwerty::CallIndirectOp>
 
 bool block_is_duplicatable(mlir::Block &in_block) {
     for (mlir::Operation &op : in_block) {
-        llvm::errs() << "Checking op";
+        DEBUG_WITH_TYPE("duplicatable", llvm::errs() << "Checking op");
         if (!mlir::isPure(&op)) {
-            llvm::errs() << "Op is not Pure";
-            op.dump();
+            DEBUG_WITH_TYPE("duplicatable", {
+                llvm::errs() << "Op is not Pure";
+                op.dump();
+            });
             return false;
         }
         for (mlir::Value operand : op.getOperands()) {
             if (llvm::isa<qcirc::NonStationaryTypeInterface>(operand.getType()) && operand.getParentBlock() != &in_block) {
-                llvm::errs() << "Operand is not defined in the same scope as block";
-                op.dump();
-                operand.dump();
+                DEBUG_WITH_TYPE("duplicatable", {
+                    llvm::errs() << "Operand is not defined in the same scope as block";
+                    op.dump();
+                    operand.dump();
+                });
                 return false;
             }
         }

--- a/qwerty_mlir/lib/Qwerty/Transforms/QwertyToQCircConversionPass.cpp
+++ b/qwerty_mlir/lib/Qwerty/Transforms/QwertyToQCircConversionPass.cpp
@@ -631,6 +631,20 @@ struct SCFYieldOpTypeFix : public mlir::OpConversionPattern<mlir::scf::YieldOp> 
     }
 };
 
+// We have to manually convert the result type of arith.select ops too
+struct ArithSelectOpTypeFix : public mlir::OpConversionPattern<mlir::arith::SelectOp> {
+    using mlir::OpConversionPattern<mlir::arith::SelectOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(mlir::arith::SelectOp select,
+                                        OpAdaptor adaptor,
+                                        mlir::ConversionPatternRewriter &rewriter) const final {
+        rewriter.replaceOpWithNewOp<mlir::arith::SelectOp>(select, adaptor.getCondition(), 
+                                                           adaptor.getTrueValue(),
+                                                           adaptor.getFalseValue());
+        return mlir::success();
+    }
+};
+
 // We also have to manually convert the result type of a qcirc.calc
 struct CalcOpTypeFix : public mlir::OpConversionPattern<qcirc::CalcOp> {
     using mlir::OpConversionPattern<qcirc::CalcOp>::OpConversionPattern;
@@ -3390,6 +3404,7 @@ struct QwertyToQCircConversionPass : public qwerty::QwertyToQCircConversionBase<
         // the right types
         target.addDynamicallyLegalOp<mlir::scf::IfOp,
                                      mlir::scf::YieldOp,
+                                     mlir::arith::SelectOp,
                                      qcirc::CalcOp,
                                      qcirc::CalcYieldOp>(
             [&](mlir::Operation *op) {
@@ -3399,6 +3414,7 @@ struct QwertyToQCircConversionPass : public qwerty::QwertyToQCircConversionBase<
         mlir::RewritePatternSet patterns(&getContext());
         patterns.add<SCFIfOpTypeFix,
                      SCFYieldOpTypeFix,
+                     ArithSelectOpTypeFix,
                      CalcOpTypeFix,
                      CalcYieldOpTypeFix,
                      QBundlePackOpLowering,

--- a/qwerty_mlir/lib/Qwerty/Transforms/QwertyToQCircConversionPass.cpp
+++ b/qwerty_mlir/lib/Qwerty/Transforms/QwertyToQCircConversionPass.cpp
@@ -638,7 +638,7 @@ struct ArithSelectOpTypeFix : public mlir::OpConversionPattern<mlir::arith::Sele
     mlir::LogicalResult matchAndRewrite(mlir::arith::SelectOp select,
                                         OpAdaptor adaptor,
                                         mlir::ConversionPatternRewriter &rewriter) const final {
-        rewriter.replaceOpWithNewOp<mlir::arith::SelectOp>(select, adaptor.getCondition(), 
+        rewriter.replaceOpWithNewOp<mlir::arith::SelectOp>(select, adaptor.getCondition(),
                                                            adaptor.getTrueValue(),
                                                            adaptor.getFalseValue());
         return mlir::success();

--- a/test/integration_tests/integration_tests.py
+++ b/test/integration_tests/integration_tests.py
@@ -119,3 +119,8 @@ class IntegrationTests(unittest.TestCase):
         histo = basis_sugar.sweet(shots=n_shots, histogram=True)
         histo_expected = {bit[1](0b0): n_shots}
         self.assertEqual(histo, histo_expected)
+    
+    def test_arith_select(self):
+        from .tests import arith_select
+        output = arith_select.test()
+        self.assertIn(output, [bit[1](0b0), bit[1](0b1)], "Final output was not in the select options!")

--- a/test/integration_tests/integration_tests.py
+++ b/test/integration_tests/integration_tests.py
@@ -119,7 +119,7 @@ class IntegrationTests(unittest.TestCase):
         histo = basis_sugar.sweet(shots=n_shots, histogram=True)
         histo_expected = {bit[1](0b0): n_shots}
         self.assertEqual(histo, histo_expected)
-    
+
     def test_arith_select(self):
         from .tests import arith_select
         output = arith_select.test()

--- a/test/integration_tests/tests/arith_select.py
+++ b/test/integration_tests/tests/arith_select.py
@@ -1,0 +1,10 @@
+from qwerty import *
+
+@qpu
+def kernel() -> bit:
+    r0 = '0'|measure
+    r1 = '1'|measure
+    return  r0 if '+'|measure else r1
+
+def test():
+    return kernel()


### PR DESCRIPTION
Currently, we cannot handle arith.select ops in the generated qwerty dialect mlir. This PR introduces functionality to resolve the same and adds integration tests for the same.

Also cleans up debugging statements from a previous PR (oopsie) in QwertyOps.