### PR TITLE
Fix span factoring

### DIFF
--- a/qwerty_ast/src/typecheck.rs
+++ b/qwerty_ast/src/typecheck.rs
@@ -2356,8 +2356,7 @@ fn factor_basis(small: &Basis, small_dim: usize, big: &Basis, big_dim: usize) ->
                 vecs: remainder_vecs,
                 dbg: dbg.clone(),
             };
-            let canon_remainder = remainder.canonicalize();
-            Some(canon_remainder)
+            Some(remainder)
         } else {
             // TODO: support many more cases
             None
@@ -2398,7 +2397,8 @@ fn basis_span_equiv(b1: &Basis, b2: &Basis) -> bool {
                         } else if be1_dim < be2_dim {
                             match factor_basis(&be1, be1_dim, &be2, be2_dim) {
                                 Some(remainder) => {
-                                    b2_stack.push(remainder);
+                                    let mut rem_stack = remainder.canonicalize().to_stack();
+                                    b2_stack.append(&mut rem_stack);
                                 }
                                 None => {
                                     // Couldn't factor
@@ -2409,7 +2409,8 @@ fn basis_span_equiv(b1: &Basis, b2: &Basis) -> bool {
                             // be1_dim > be2_dim
                             match factor_basis(&be2, be2_dim, &be1, be1_dim) {
                                 Some(remainder) => {
-                                    b1_stack.push(remainder);
+                                    let mut rem_stack = remainder.canonicalize().to_stack();
+                                    b1_stack.append(&mut rem_stack);
                                 }
                                 None => {
                                     // Couldn't factor

--- a/qwerty_pyrt/python/qwerty/tests/integ/meta/qft.py
+++ b/qwerty_pyrt/python/qwerty/tests/integ/meta/qft.py
@@ -1,0 +1,19 @@
+"""
+Test a basis translation between a 3-qubit basis generated with basis
+generators and a 3-fold tensor product of a one-qubit basis. This causes span
+equivalence checking to factor the bigger basis.
+"""
+
+from qwerty import *
+
+@qpu
+def qft() -> bit[3]:
+    return '0'**3 | std**3 >> fourier[3] | pm.measure**3
+
+@qpu
+def iqft() -> bit[3]:
+    return 'p'**3 | fourier[3] >> std**3 | measure**3
+
+def test(shots):
+    return (qft(shots=shots),
+            iqft(shots=shots))

--- a/qwerty_pyrt/python/qwerty/tests/integration_tests.py
+++ b/qwerty_pyrt/python/qwerty/tests/integration_tests.py
@@ -433,6 +433,14 @@ class MetaInferIntegrationTests(unittest.TestCase):
         self.assertEqual(expected_histo, actual_histo_normal)
         self.assertEqual(expected_histo, actual_histo_gen_ast)
 
+    def test_qft(self):
+        from .integ.meta import qft
+        shots = 1024
+        expected_histos = ({bit[3](0b000): shots},
+                           {bit[3](0b000): shots})
+        actual_histos = qft.test(shots)
+        self.assertEqual(expected_histos, actual_histos)
+
 @unittest.skipIf(should_skip, skip_msg)
 class QCE25FigureIntegrationTests(unittest.TestCase):
     """The figures from the QCE '25 paper as integration tests."""


### PR DESCRIPTION
Right now, `std**3 >> fourier[3]` fails the span equivalence check because `basis_span_equiv()` in `qwerty_ast/typecheck.rs` is broken. The `b1_stack` and `b2_stack` are expected to contain only basis elements, i.e., no `BasisTensor` nodes. However, `basis_span_equiv()` incorrectly pushes the remainder from basis factoring, which may be a `BasisTensor` node, directly to the stack instead of pushing its constituent basis elements. This commit fixes this and adds an integration test to catch any future regressions.

### Testing

Compiles and `dev/run-tests.sh` passes