### PR TITLE
Typecheck classical expr update

### DIFF
--- a/qwerty_ast/src/typecheck.rs
+++ b/qwerty_ast/src/typecheck.rs
@@ -4,6 +4,7 @@ use crate::dbg::DebugLoc;
 use crate::error::{TypeError, TypeErrorKind};
 use dashu::base::BitTest;
 use num_integer::gcd;
+use qwerty_ast_macros::visitor_expr;
 use std::collections::{HashMap, HashSet};
 use std::iter::zip;
 
@@ -1520,81 +1521,44 @@ impl TypeCheckable for classical::Expr {
     }
 
     fn typecheck(&self, env: &mut TypeEnv) -> Result<(Type, ComputeKind), TypeError> {
-        match self {
+        visitor_expr! {classical::Expr, self,
             classical::Expr::Variable(var) => var.calc_type(env),
             classical::Expr::BitLiteral(bit_lit) => bit_lit.calc_type(),
             classical::Expr::Slice(slice) => {
-                let val_result = slice.val.typecheck(env)?;
+                let val_result = visit!(*slice.val)?;
                 slice.calc_type(&val_result)
-            }
+            },
             classical::Expr::UnaryOp(unary_op) => {
-                let UnaryOp { val, .. } = unary_op;
-                let val_result = val.typecheck(env)?;
+                let val_result = visit!(*unary_op.val)?;
                 unary_op.calc_type(&val_result)
-            }
+            },
             classical::Expr::BinaryOp(binary_op) => {
-                let BinaryOp {
-                    kind: _,
-                    left,
-                    right,
-                    dbg: _,
-                } = binary_op;
-
-                let left_result = left.typecheck(env)?;
-                let right_result = right.typecheck(env)?;
+                let left_result = visit!(*binary_op.left)?;
+                let right_result = visit!(*binary_op.right)?;
                 binary_op.calc_type(&left_result, &right_result)
-            }
+            },
             classical::Expr::ReduceOp(reduce_op) => {
-                let ReduceOp {
-                    kind: _,
-                    val,
-                    dbg: _,
-                } = reduce_op;
-                let val_result = val.typecheck(env)?;
+                let val_result = visit!(*reduce_op.val)?;
                 reduce_op.calc_type(&val_result)
-            }
+            },
             classical::Expr::RotateOp(rotate_op) => {
-                let RotateOp {
-                    kind: _,
-                    val,
-                    amt,
-                    dbg: _,
-                } = rotate_op;
-                let val_result = val.typecheck(env)?;
-                let amt_result = amt.typecheck(env)?;
+                let val_result = visit!(*rotate_op.val)?;
+                let amt_result = visit!(*rotate_op.amt)?;
                 rotate_op.calc_type(&val_result, &amt_result)
-            }
+            },
             classical::Expr::Concat(concat) => {
-                let Concat {
-                    left,
-                    right,
-                    dbg: _,
-                } = concat;
-                let left_result = left.typecheck(env)?;
-                let right_result = right.typecheck(env)?;
-
+                let left_result = visit!(*concat.left)?;
+                let right_result = visit!(*concat.right)?;
                 concat.calc_type(&left_result, &right_result)
-            }
+            },
             classical::Expr::Repeat(repeat) => {
-                let Repeat {
-                    val,
-                    amt: _,
-                    dbg: _,
-                } = repeat;
-                let val_result = val.typecheck(env)?;
+                let val_result = visit!(*repeat.val)?;
                 repeat.calc_type(&val_result)
-            }
+            },
             classical::Expr::ModMul(mod_mul) => {
-                let ModMul {
-                    x: _,
-                    j: _,
-                    y,
-                    mod_n: _,
-                    dbg: _,
-                } = mod_mul;
-                let y_result = y.typecheck(env)?;
+                let y_result = visit!(*mod_mul.y)?;
                 mod_mul.calc_type(&y_result)
-            }
+            },
         }
     }
 }

--- a/qwerty_ast_macros/src/visitor/parse.rs
+++ b/qwerty_ast_macros/src/visitor/parse.rs
@@ -3,6 +3,7 @@ use proc_macro2::Span;
 use syn::{
     Arm, Block, Error, Expr, ExprBinary, ExprBlock, ExprMacro, ExprPath, ExprUnary, Ident, LitStr,
     Macro, Stmt, Token, Type,
+    Local, LocalInit,
     parse::{Parse, ParseStream},
     spanned::Spanned,
 };
@@ -382,6 +383,53 @@ fn parse_visitor_expr_arm_expr_helper(
                 visit_exprs_out,
             )?);
             Ok(Expr::Unary(ExprUnary { attrs, op, expr }))
+        }
+
+        Expr::Block(ExprBlock { attrs, label, block }) => {
+			let Block { brace_token, stmts } = block;
+			let stmts = stmts
+				.into_iter()
+				.map(|stmt| {
+					match stmt {
+						Stmt::Expr(expr, semi_token) => {
+							let expr = parse_visitor_expr_arm_expr_helper(expr, visit_var_name_gen, visit_exprs_out)?;
+							Ok(Stmt::Expr(expr, semi_token))
+						},
+						Stmt::Local(Local {attrs, let_token, pat, init, semi_token}) => {
+							// If we have a local initialization i.e let x = 3
+							let init = match init {
+								Some(LocalInit { eq_token, expr, diverge }) => {
+									let diverge = match diverge {
+										Some((else_token, diverge_expr)) => {
+											let diverge_expr = parse_visitor_expr_arm_expr_helper(*diverge_expr, visit_var_name_gen, visit_exprs_out)?;
+											Some((else_token, Box::new(diverge_expr)))
+										},
+										None => None,
+									};
+									let expr = parse_visitor_expr_arm_expr_helper(*expr, visit_var_name_gen, visit_exprs_out)?;
+									Some(LocalInit{eq_token, expr: Box::new(expr), diverge: diverge})
+								}
+								None => None,
+							};
+							Ok(Stmt::Local(Local {attrs, let_token, pat, init, semi_token}))
+						},
+						// Check to make sure someone is not trying to use the {} syntax with visit!
+						// All normal visit calls should be parsed as Expr::Macro
+						Stmt::Macro(ref stmt_mac)
+							if (paths::path_is_ident_str(&stmt_mac.mac.path, "visit")) => {
+								Err(Error::new_spanned(
+									stmt_mac,
+									"visit! {...} with braces is not supported in visitor_expr!, \
+									use visit!(...) instead"
+								))
+							}
+						passthru @ (Stmt::Item(_) | Stmt::Macro(_)) => Ok(passthru),
+					}
+				}).collect::<Result<Vec<Stmt>, Error>>()?;
+
+			let block = Block {brace_token, stmts: stmts};
+
+			Ok(Expr::Block(ExprBlock{attrs, label, block}))
         }
 
         Expr::Macro(ExprMacro {

--- a/qwerty_ast_macros/src/visitor/parse.rs
+++ b/qwerty_ast_macros/src/visitor/parse.rs
@@ -1,7 +1,12 @@
 use crate::syn_util::paths;
 use proc_macro2::Span;
 use syn::{
-    Arm, Block, Error, Expr, ExprBinary, ExprBlock, ExprCall, ExprMacro, ExprMethodCall, ExprParen, ExprPath, ExprUnary, Ident, LitStr, Local, LocalInit, Macro, Stmt, Token, Type, parse::{Parse, ParseStream}, punctuated::Punctuated, spanned::Spanned
+    Arm, Block, Error, Expr, ExprBinary, ExprBlock, ExprCall, ExprMacro, ExprMethodCall, ExprParen,
+    ExprPath, ExprReference, ExprTry, ExprUnary, Ident, LitStr, Local, LocalInit, Macro, Stmt,
+    Token, Type,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    spanned::Spanned,
 };
 
 /// Holds the parsed arguments for a call to `visitor_write!{}` or
@@ -380,75 +385,166 @@ fn parse_visitor_expr_arm_expr_helper(
             )?);
             Ok(Expr::Unary(ExprUnary { attrs, op, expr }))
         }
-        Expr::Block(ExprBlock { attrs, label, block }) => {
-			let Block { brace_token, stmts } = block;
-			let stmts = stmts
-				.into_iter()
-				.map(|stmt| {
-					match stmt {
-						Stmt::Expr(expr, semi_token) => {
-							let expr = parse_visitor_expr_arm_expr_helper(expr, visit_var_name_gen, visit_exprs_out)?;
-							Ok(Stmt::Expr(expr, semi_token))
-						},
-						Stmt::Local(Local {attrs, let_token, pat, init, semi_token}) => {
-							// If we have a local initialization i.e let x = 3
-							let init = match init {
-								Some(LocalInit { eq_token, expr, diverge }) => {
-									let diverge = match diverge {
-										Some((else_token, diverge_expr)) => {
-											let diverge_expr = parse_visitor_expr_arm_expr_helper(*diverge_expr, visit_var_name_gen, visit_exprs_out)?;
-											Some((else_token, Box::new(diverge_expr)))
-										},
-										None => None,
-									};
-									let expr = parse_visitor_expr_arm_expr_helper(*expr, visit_var_name_gen, visit_exprs_out)?;
-									Some(LocalInit{eq_token, expr: Box::new(expr), diverge: diverge})
-								}
-								None => None,
-							};
-							Ok(Stmt::Local(Local {attrs, let_token, pat, init, semi_token}))
-						},
-						// Check to make sure someone is not trying to use the {} syntax with visit!
-						// All normal visit calls should be parsed as Expr::Macro
-						Stmt::Macro(ref stmt_mac)
-							if (paths::path_is_ident_str(&stmt_mac.mac.path, "visit")) => {
-								Err(Error::new_spanned(
-									stmt_mac,
-									"visit! {...} with braces is not supported in visitor_expr!, \
-									use visit!(...) instead"
-								))
-							},
-						passthru @ (Stmt::Item(_) | Stmt::Macro(_)) => Ok(passthru),
-					}
-				}).collect::<Result<Vec<Stmt>, Error>>()?;
+        Expr::Block(ExprBlock {
+            attrs,
+            label,
+            block,
+        }) => {
+            let Block { brace_token, stmts } = block;
+            let stmts = stmts
+                .into_iter()
+                .map(|stmt| {
+                    match stmt {
+                        Stmt::Expr(expr, semi_token) => {
+                            let expr = parse_visitor_expr_arm_expr_helper(
+                                expr,
+                                visit_var_name_gen,
+                                visit_exprs_out,
+                            )?;
+                            Ok(Stmt::Expr(expr, semi_token))
+                        }
+                        Stmt::Local(Local {
+                            attrs,
+                            let_token,
+                            pat,
+                            init,
+                            semi_token,
+                        }) => {
+                            // If we have a local initialization i.e let x = 3
+                            let init = match init {
+                                Some(LocalInit {
+                                    eq_token,
+                                    expr,
+                                    diverge,
+                                }) => {
+                                    let diverge = match diverge {
+                                        Some((else_token, diverge_expr)) => {
+                                            let diverge_expr = parse_visitor_expr_arm_expr_helper(
+                                                *diverge_expr,
+                                                visit_var_name_gen,
+                                                visit_exprs_out,
+                                            )?;
+                                            Some((else_token, Box::new(diverge_expr)))
+                                        }
+                                        None => None,
+                                    };
+                                    let expr = parse_visitor_expr_arm_expr_helper(
+                                        *expr,
+                                        visit_var_name_gen,
+                                        visit_exprs_out,
+                                    )?;
+                                    Some(LocalInit {
+                                        eq_token,
+                                        expr: Box::new(expr),
+                                        diverge: diverge,
+                                    })
+                                }
+                                None => None,
+                            };
+                            Ok(Stmt::Local(Local {
+                                attrs,
+                                let_token,
+                                pat,
+                                init,
+                                semi_token,
+                            }))
+                        }
+                        // Check to make sure someone is not trying to use the {} syntax with visit!
+                        // All normal visit calls should be parsed as Expr::Macro
+                        Stmt::Macro(ref stmt_mac)
+                            if (paths::path_is_ident_str(&stmt_mac.mac.path, "visit")) =>
+                        {
+                            Err(Error::new_spanned(
+                                stmt_mac,
+                                "visit! {...} with braces is not supported in visitor_expr!, \
+									use visit!(...) instead",
+                            ))
+                        }
+                        passthru @ (Stmt::Item(_) | Stmt::Macro(_)) => Ok(passthru),
+                    }
+                })
+                .collect::<Result<Vec<Stmt>, Error>>()?;
 
-			let block = Block {brace_token, stmts: stmts};
+            let block = Block {
+                brace_token,
+                stmts: stmts,
+            };
 
-			Ok(Expr::Block(ExprBlock{attrs, label, block}))
-        },
-        Expr::Paren(ExprParen {attrs, paren_token, expr}) => {
-			let expr = parse_visitor_expr_arm_expr_helper(*expr, visit_var_name_gen, visit_exprs_out)?;
-			Ok(Expr::Paren(ExprParen {attrs, paren_token, expr: Box::new(expr)}))
+            Ok(Expr::Block(ExprBlock {
+                attrs,
+                label,
+                block,
+            }))
         }
-        // Note: func is of type Box<Expr>, we do not recuse on this type
-        Expr::Call(ExprCall {attrs, func, paren_token, args}) => {
-	        let args = args
-		        .into_iter()
-		        .map(|arg_expr| {
-					parse_visitor_expr_arm_expr_helper(arg_expr, visit_var_name_gen, visit_exprs_out)
-			    }).collect::<Result<Punctuated<Expr, Token![,]>, Error>>()?;
-			Ok(Expr::Call(ExprCall {attrs, func, paren_token, args}))
+        Expr::Paren(ExprParen {
+            attrs,
+            paren_token,
+            expr,
+        }) => {
+            let expr =
+                parse_visitor_expr_arm_expr_helper(*expr, visit_var_name_gen, visit_exprs_out)?;
+            Ok(Expr::Paren(ExprParen {
+                attrs,
+                paren_token,
+                expr: Box::new(expr),
+            }))
         }
-        Expr::MethodCall(ExprMethodCall {attrs, receiver, dot_token, method, turbofish, paren_token, args}) => {
-	        let receiver_expr = parse_visitor_expr_arm_expr_helper(*receiver, visit_var_name_gen, visit_exprs_out)?;
+        // Note: func is of type Box<Expr>, we do not recurse on this type
+        Expr::Call(ExprCall {
+            attrs,
+            func,
+            paren_token,
+            args,
+        }) => {
+            let args = args
+                .into_iter()
+                .map(|arg_expr| {
+                    parse_visitor_expr_arm_expr_helper(
+                        arg_expr,
+                        visit_var_name_gen,
+                        visit_exprs_out,
+                    )
+                })
+                .collect::<Result<Punctuated<Expr, Token![,]>, Error>>()?;
+            Ok(Expr::Call(ExprCall {
+                attrs,
+                func,
+                paren_token,
+                args,
+            }))
+        }
+        Expr::MethodCall(ExprMethodCall {
+            attrs,
+            receiver,
+            dot_token,
+            method,
+            turbofish,
+            paren_token,
+            args,
+        }) => {
+            let receiver_expr =
+                parse_visitor_expr_arm_expr_helper(*receiver, visit_var_name_gen, visit_exprs_out)?;
 
-	        let args = args
-		        .into_iter()
-		        .map(|arg_expr| {
-					parse_visitor_expr_arm_expr_helper(arg_expr, visit_var_name_gen, visit_exprs_out)
-			    }).collect::<Result<Punctuated<Expr, Token![,]>, Error>>()?;
-		    Ok(Expr::MethodCall(ExprMethodCall { attrs, receiver: Box::new(receiver_expr), dot_token, method, turbofish, paren_token, args }))
-        },
+            let args = args
+                .into_iter()
+                .map(|arg_expr| {
+                    parse_visitor_expr_arm_expr_helper(
+                        arg_expr,
+                        visit_var_name_gen,
+                        visit_exprs_out,
+                    )
+                })
+                .collect::<Result<Punctuated<Expr, Token![,]>, Error>>()?;
+            Ok(Expr::MethodCall(ExprMethodCall {
+                attrs,
+                receiver: Box::new(receiver_expr),
+                dot_token,
+                method,
+                turbofish,
+                paren_token,
+                args,
+            }))
+        }
         Expr::Macro(ExprMacro {
             attrs,
             mac:
@@ -481,13 +577,50 @@ fn parse_visitor_expr_arm_expr_helper(
                 Ok(var_name_expr)
             }
         }
+        Expr::Try(ExprTry {
+            attrs,
+            expr,
+            question_token,
+        }) => {
+            let expr = Box::new(parse_visitor_expr_arm_expr_helper(
+                *expr,
+                visit_var_name_gen,
+                visit_exprs_out,
+            )?);
+            Ok(Expr::Try(ExprTry {
+                attrs,
+                expr,
+                question_token,
+            }))
+        }
 
+        Expr::Reference(ExprReference {
+            attrs,
+            and_token,
+            mutability,
+            expr,
+        }) => {
+            let expr = Box::new(parse_visitor_expr_arm_expr_helper(
+                *expr,
+                visit_var_name_gen,
+                visit_exprs_out,
+            )?);
+            Ok(Expr::Reference(ExprReference {
+                attrs,
+                and_token,
+                mutability,
+                expr,
+            }))
+        }
         passthru @ (Expr::Lit(_) | Expr::Path(_)) => Ok(passthru),
 
-        other_expr => Err(Error::new_spanned(
-            other_expr,
-            "Unknown expression inside visitor_expr! arm",
-        )),
+        other_expr => {
+            let err_msg = format!(
+                "Unknown expression inside visitor_expr! arm: {:?}",
+                other_expr
+            );
+            Err(Error::new_spanned(other_expr, err_msg))
+        }
     }
 }
 

--- a/qwerty_ast_macros/src/visitor/parse.rs
+++ b/qwerty_ast_macros/src/visitor/parse.rs
@@ -385,6 +385,7 @@ fn parse_visitor_expr_arm_expr_helper(
             )?);
             Ok(Expr::Unary(ExprUnary { attrs, op, expr }))
         }
+
         Expr::Block(ExprBlock {
             attrs,
             label,
@@ -449,15 +450,13 @@ fn parse_visitor_expr_arm_expr_helper(
                                 semi_token,
                             }))
                         }
-                        // Check to make sure someone is not trying to use the {} syntax with visit!
-                        // All normal visit calls should be parsed as Expr::Macro
+                        // All visit calls should be parsed as Expr::Macro
                         Stmt::Macro(ref stmt_mac)
                             if (paths::path_is_ident_str(&stmt_mac.mac.path, "visit")) =>
                         {
                             Err(Error::new_spanned(
                                 stmt_mac,
-                                "visit! {...} with braces is not supported in visitor_expr!, \
-									use visit!(...) instead",
+                                "visit!(...) as statement not yet supported",
                             ))
                         }
                         passthru @ (Stmt::Item(_) | Stmt::Macro(_)) => Ok(passthru),
@@ -476,6 +475,7 @@ fn parse_visitor_expr_arm_expr_helper(
                 block,
             }))
         }
+
         Expr::Paren(ExprParen {
             attrs,
             paren_token,
@@ -489,13 +489,18 @@ fn parse_visitor_expr_arm_expr_helper(
                 expr: Box::new(expr),
             }))
         }
-        // Note: func is of type Box<Expr>, we do not recurse on this type
+
         Expr::Call(ExprCall {
             attrs,
             func,
             paren_token,
             args,
         }) => {
+            let func = Box::new(parse_visitor_expr_arm_expr_helper(
+                *func,
+                visit_var_name_gen,
+                visit_exprs_out,
+            )?);
             let args = args
                 .into_iter()
                 .map(|arg_expr| {
@@ -513,6 +518,7 @@ fn parse_visitor_expr_arm_expr_helper(
                 args,
             }))
         }
+
         Expr::MethodCall(ExprMethodCall {
             attrs,
             receiver,
@@ -545,6 +551,7 @@ fn parse_visitor_expr_arm_expr_helper(
                 args,
             }))
         }
+
         Expr::Macro(ExprMacro {
             attrs,
             mac:
@@ -577,6 +584,7 @@ fn parse_visitor_expr_arm_expr_helper(
                 Ok(var_name_expr)
             }
         }
+
         Expr::Try(ExprTry {
             attrs,
             expr,
@@ -612,6 +620,7 @@ fn parse_visitor_expr_arm_expr_helper(
                 expr,
             }))
         }
+
         passthru @ (Expr::Lit(_) | Expr::Path(_)) => Ok(passthru),
 
         other_expr => {

--- a/qwerty_ast_macros/src/visitor/parse.rs
+++ b/qwerty_ast_macros/src/visitor/parse.rs
@@ -1,7 +1,7 @@
 use crate::syn_util::paths;
 use proc_macro2::Span;
 use syn::{
-    Arm, Block, Error, Expr, ExprBinary, ExprBlock, ExprCall, ExprMacro, ExprMethodCall, ExprPath, ExprUnary, Ident, LitStr, Local, LocalInit, Macro, Stmt, Token, Type, parse::{Parse, ParseStream}, punctuated::Punctuated, spanned::Spanned
+    Arm, Block, Error, Expr, ExprBinary, ExprBlock, ExprCall, ExprMacro, ExprMethodCall, ExprParen, ExprPath, ExprUnary, Ident, LitStr, Local, LocalInit, Macro, Stmt, Token, Type, parse::{Parse, ParseStream}, punctuated::Punctuated, spanned::Spanned
 };
 
 /// Holds the parsed arguments for a call to `visitor_write!{}` or
@@ -426,6 +426,10 @@ fn parse_visitor_expr_arm_expr_helper(
 
 			Ok(Expr::Block(ExprBlock{attrs, label, block}))
         },
+        Expr::Paren(ExprParen {attrs, paren_token, expr}) => {
+			let expr = parse_visitor_expr_arm_expr_helper(*expr, visit_var_name_gen, visit_exprs_out)?;
+			Ok(Expr::Paren(ExprParen {attrs, paren_token, expr: Box::new(expr)}))
+        }
         // Note: func is of type Box<Expr>, we do not recuse on this type
         Expr::Call(ExprCall {attrs, func, paren_token, args}) => {
 	        let args = args

--- a/qwerty_ast_macros/src/visitor/parse.rs
+++ b/qwerty_ast_macros/src/visitor/parse.rs
@@ -1,11 +1,7 @@
 use crate::syn_util::paths;
 use proc_macro2::Span;
 use syn::{
-    Arm, Block, Error, Expr, ExprBinary, ExprBlock, ExprMacro, ExprPath, ExprUnary, Ident, LitStr,
-    Macro, Stmt, Token, Type,
-    Local, LocalInit,
-    parse::{Parse, ParseStream},
-    spanned::Spanned,
+    Arm, Block, Error, Expr, ExprBinary, ExprBlock, ExprCall, ExprMacro, ExprMethodCall, ExprPath, ExprUnary, Ident, LitStr, Local, LocalInit, Macro, Stmt, Token, Type, parse::{Parse, ParseStream}, punctuated::Punctuated, spanned::Spanned
 };
 
 /// Holds the parsed arguments for a call to `visitor_write!{}` or
@@ -384,7 +380,6 @@ fn parse_visitor_expr_arm_expr_helper(
             )?);
             Ok(Expr::Unary(ExprUnary { attrs, op, expr }))
         }
-
         Expr::Block(ExprBlock { attrs, label, block }) => {
 			let Block { brace_token, stmts } = block;
 			let stmts = stmts
@@ -422,7 +417,7 @@ fn parse_visitor_expr_arm_expr_helper(
 									"visit! {...} with braces is not supported in visitor_expr!, \
 									use visit!(...) instead"
 								))
-							}
+							},
 						passthru @ (Stmt::Item(_) | Stmt::Macro(_)) => Ok(passthru),
 					}
 				}).collect::<Result<Vec<Stmt>, Error>>()?;
@@ -430,8 +425,26 @@ fn parse_visitor_expr_arm_expr_helper(
 			let block = Block {brace_token, stmts: stmts};
 
 			Ok(Expr::Block(ExprBlock{attrs, label, block}))
+        },
+        // Note: func is of type Box<Expr>, we do not recuse on this type
+        Expr::Call(ExprCall {attrs, func, paren_token, args}) => {
+	        let args = args
+		        .into_iter()
+		        .map(|arg_expr| {
+					parse_visitor_expr_arm_expr_helper(arg_expr, visit_var_name_gen, visit_exprs_out)
+			    }).collect::<Result<Punctuated<Expr, Token![,]>, Error>>()?;
+			Ok(Expr::Call(ExprCall {attrs, func, paren_token, args}))
         }
+        Expr::MethodCall(ExprMethodCall {attrs, receiver, dot_token, method, turbofish, paren_token, args}) => {
+	        let receiver_expr = parse_visitor_expr_arm_expr_helper(*receiver, visit_var_name_gen, visit_exprs_out)?;
 
+	        let args = args
+		        .into_iter()
+		        .map(|arg_expr| {
+					parse_visitor_expr_arm_expr_helper(arg_expr, visit_var_name_gen, visit_exprs_out)
+			    }).collect::<Result<Punctuated<Expr, Token![,]>, Error>>()?;
+		    Ok(Expr::MethodCall(ExprMethodCall { attrs, receiver: Box::new(receiver_expr), dot_token, method, turbofish, paren_token, args }))
+        },
         Expr::Macro(ExprMacro {
             attrs,
             mac:


### PR DESCRIPTION
Updated classical::expr typechecking to do calculations on the heap instead of the stack.