### PR TITLE
Add conversion code and tests for CCircToXAG

### DIFF
--- a/qwerty_mlir/lib/CCirc/Transforms/CCircToXAGConversionPass.cpp
+++ b/qwerty_mlir/lib/CCirc/Transforms/CCircToXAGConversionPass.cpp
@@ -12,20 +12,20 @@
 // 1. Semantics are identical to the original circuit
 // 2. Every child ops is either structural (ccirc.return, ccirc.wirepack,
 //    ccirc.wireunpack)
-// 3. ...or every child op is one of the following logical ops with 1-bit
-//    operands and 1-bit results:
+// 3. ...or every child op is one of the following logical ops with Single-bit
+//    operands and Single-bit results:
 //    a) ccirc.not
 //    b) ccirc.and
 //    c) ccirc.parity
 //    d) ccirc.constant
 // Other logic ops (e.g., ccirc.or) are initially decomposed into intermediate
-// multi-bit versions of the above ops, which are then decomposed into
+// Multi-bit versions of the above ops, which are then decomposed into
 // structural ops and logical ops (a)-(d) above.
 // Running the canonicalizer after this pass will remove redundant
 // packing/unpacking, deduplicate constant ops, simplify idioms such as
 // `x XOR 0`, merge parity ops, and propagate not ops through parity ops,
 // producing a high-level XAG [1]. That is, a digital logic circuit containing
-// only 1-bit ANDs, 1-bit parity ops whose results may be negated, and an
+// only Single-bit ANDs, Single-bit parity ops whose results may be negated, and an
 // optional final NOT on outputs [1].
 //
 // [1]: https://doi.org/10.23919/DATE51398.2021.9474163
@@ -67,7 +67,7 @@ struct SplitMultiBitConstant
     }
 };
 
-// Split multi-bit AND into element-wise 1-bit ANDs.
+// Split Multi-bit AND into element-wise Single-bit ANDs.
 struct SplitMultiBitAnd
         : public mlir::OpConversionPattern<ccirc::AndOp> {
     using mlir::OpConversionPattern<ccirc::AndOp>::OpConversionPattern;
@@ -97,7 +97,7 @@ struct SplitMultiBitAnd
     }
 };
 
-// Split multi-bit NOT into element-wise 1-bit NOTs.
+// Split Multi-bit NOT into element-wise Single-bit NOTs.
 struct SplitMultiBitNot
         : public mlir::OpConversionPattern<ccirc::NotOp> {
     using mlir::OpConversionPattern<ccirc::NotOp>::OpConversionPattern;
@@ -125,7 +125,7 @@ struct SplitMultiBitNot
     }
 };
 
-// Split multi-bit PARITY into per-bit 1-bit parities.
+// Split Multi-bit PARITY into per-bit Single-bit parities.
 // parity(a[N], b[N], ...) becomes wirepack of parity(a[i], b[i], ...) for each i.
 struct SplitMultiBitParity
         : public mlir::OpConversionPattern<ccirc::ParityOp> {
@@ -164,7 +164,7 @@ struct SplitMultiBitParity
     }
 };
 
-// Split multi-bit OR into element-wise 1-bit ORs.
+// Split Multi-bit OR into element-wise Single-bit ORs.
 // Single-bit ORs are then handled by DecomposeOrToDeMorgan.
 struct SplitMultiBitOr
         : public mlir::OpConversionPattern<ccirc::OrOp> {
@@ -195,7 +195,7 @@ struct SplitMultiBitOr
     }
 };
 
-// Split multi-bit XOR into element-wise 1-bit XORs.
+// Split Multi-bit XOR into element-wise Single-bit XORs.
 // Single-bit XORs are then handled by DecomposeXorToParity.
 struct SplitMultiBitXor
         : public mlir::OpConversionPattern<ccirc::XorOp> {
@@ -286,7 +286,7 @@ struct CCircToXAGConversionPass
                           // these guys
                           ccirc::WirePackOp,
                           ccirc::WireUnpackOp>();
-        // A XAG should not have any multi-bit bitwise operations
+        // A XAG should not have any Multi-bit bitwise operations
         target.addDynamicallyLegalOp<ccirc::AndOp,
                                      ccirc::NotOp,
                                      ccirc::ParityOp,

--- a/qwerty_mlir/lib/CCirc/Transforms/CCircToXAGConversionPass.cpp
+++ b/qwerty_mlir/lib/CCirc/Transforms/CCircToXAGConversionPass.cpp
@@ -67,6 +67,213 @@ struct SplitMultiBitConstant
     }
 };
 
+// Split multi-bit AND into element-wise 1-bit ANDs.
+struct SplitMultiBitAnd
+        : public mlir::OpConversionPattern<ccirc::AndOp> {
+    using mlir::OpConversionPattern<ccirc::AndOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(
+            ccirc::AndOp op,
+            OpAdaptor adaptor,
+            mlir::ConversionPatternRewriter &rewriter) const final {
+        if (op.getResult().getType().getDim() <= 1) {
+            return mlir::failure();
+        }
+
+        mlir::Location loc = op.getLoc();
+        mlir::ValueRange left_wires = rewriter.create<ccirc::WireUnpackOp>(
+            loc, op.getLeft()).getWires();
+        mlir::ValueRange right_wires = rewriter.create<ccirc::WireUnpackOp>(
+            loc, op.getRight()).getWires();
+
+        llvm::SmallVector<mlir::Value> result_wires;
+        for (auto [l, r] : llvm::zip(left_wires, right_wires)) {
+            result_wires.push_back(
+                rewriter.create<ccirc::AndOp>(loc, l, r).getResult());
+        }
+
+        rewriter.replaceOpWithNewOp<ccirc::WirePackOp>(op, result_wires);
+        return mlir::success();
+    }
+};
+
+// Split multi-bit NOT into element-wise 1-bit NOTs.
+struct SplitMultiBitNot
+        : public mlir::OpConversionPattern<ccirc::NotOp> {
+    using mlir::OpConversionPattern<ccirc::NotOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(
+            ccirc::NotOp op,
+            OpAdaptor adaptor,
+            mlir::ConversionPatternRewriter &rewriter) const final {
+        if (op.getResult().getType().getDim() <= 1) {
+            return mlir::failure();
+        }
+
+        mlir::Location loc = op.getLoc();
+        mlir::ValueRange wires = rewriter.create<ccirc::WireUnpackOp>(
+            loc, op.getOperand()).getWires();
+
+        llvm::SmallVector<mlir::Value> result_wires;
+        for (mlir::Value w : wires) {
+            result_wires.push_back(
+                rewriter.create<ccirc::NotOp>(loc, w).getResult());
+        }
+
+        rewriter.replaceOpWithNewOp<ccirc::WirePackOp>(op, result_wires);
+        return mlir::success();
+    }
+};
+
+// Split multi-bit PARITY into per-bit 1-bit parities.
+// parity(a[N], b[N], ...) becomes wirepack of parity(a[i], b[i], ...) for each i.
+struct SplitMultiBitParity
+        : public mlir::OpConversionPattern<ccirc::ParityOp> {
+    using mlir::OpConversionPattern<ccirc::ParityOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(
+            ccirc::ParityOp op,
+            OpAdaptor adaptor,
+            mlir::ConversionPatternRewriter &rewriter) const final {
+        if (op.getType().getDim() <= 1) {
+            return mlir::failure();
+        }
+
+        mlir::Location loc = op.getLoc();
+        uint64_t dim = op.getType().getDim();
+
+        llvm::SmallVector<llvm::SmallVector<mlir::Value>> unpacked;
+        for (mlir::Value operand : op.getOperands()) {
+            mlir::ValueRange wires = rewriter.create<ccirc::WireUnpackOp>(
+                loc, operand).getWires();
+            unpacked.push_back(llvm::SmallVector<mlir::Value>(wires));
+        }
+
+        llvm::SmallVector<mlir::Value> result_wires;
+        for (uint64_t i = 0; i < dim; i++) {
+            llvm::SmallVector<mlir::Value> per_bit;
+            for (auto &unp : unpacked) {
+                per_bit.push_back(unp[i]);
+            }
+            result_wires.push_back(
+                rewriter.create<ccirc::ParityOp>(loc, per_bit).getResult());
+        }
+
+        rewriter.replaceOpWithNewOp<ccirc::WirePackOp>(op, result_wires);
+        return mlir::success();
+    }
+};
+
+// Split multi-bit OR into element-wise 1-bit ORs.
+// Single-bit ORs are then handled by DecomposeOrToDeMorgan.
+struct SplitMultiBitOr
+        : public mlir::OpConversionPattern<ccirc::OrOp> {
+    using mlir::OpConversionPattern<ccirc::OrOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(
+            ccirc::OrOp op,
+            OpAdaptor adaptor,
+            mlir::ConversionPatternRewriter &rewriter) const final {
+        if (op.getResult().getType().getDim() <= 1) {
+            return mlir::failure();
+        }
+
+        mlir::Location loc = op.getLoc();
+        mlir::ValueRange left_wires = rewriter.create<ccirc::WireUnpackOp>(
+            loc, op.getLeft()).getWires();
+        mlir::ValueRange right_wires = rewriter.create<ccirc::WireUnpackOp>(
+            loc, op.getRight()).getWires();
+
+        llvm::SmallVector<mlir::Value> result_wires;
+        for (auto [l, r] : llvm::zip(left_wires, right_wires)) {
+            result_wires.push_back(
+                rewriter.create<ccirc::OrOp>(loc, l, r).getResult());
+        }
+
+        rewriter.replaceOpWithNewOp<ccirc::WirePackOp>(op, result_wires);
+        return mlir::success();
+    }
+};
+
+// Split multi-bit XOR into element-wise 1-bit XORs.
+// Single-bit XORs are then handled by DecomposeXorToParity.
+struct SplitMultiBitXor
+        : public mlir::OpConversionPattern<ccirc::XorOp> {
+    using mlir::OpConversionPattern<ccirc::XorOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(
+            ccirc::XorOp op,
+            OpAdaptor adaptor,
+            mlir::ConversionPatternRewriter &rewriter) const final {
+        if (op.getResult().getType().getDim() <= 1) {
+            return mlir::failure();
+        }
+
+        mlir::Location loc = op.getLoc();
+        mlir::ValueRange left_wires = rewriter.create<ccirc::WireUnpackOp>(
+            loc, op.getLeft()).getWires();
+        mlir::ValueRange right_wires = rewriter.create<ccirc::WireUnpackOp>(
+            loc, op.getRight()).getWires();
+
+        llvm::SmallVector<mlir::Value> result_wires;
+        for (auto [l, r] : llvm::zip(left_wires, right_wires)) {
+            result_wires.push_back(
+                rewriter.create<ccirc::XorOp>(loc, l, r).getResult());
+        }
+
+        rewriter.replaceOpWithNewOp<ccirc::WirePackOp>(op, result_wires);
+        return mlir::success();
+    }
+};
+
+// Decompose single-bit OR via De Morgan's law:
+// or(a, b) = not(and(not(a), not(b)))
+struct DecomposeOrToDeMorgan
+        : public mlir::OpConversionPattern<ccirc::OrOp> {
+    using mlir::OpConversionPattern<ccirc::OrOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(
+            ccirc::OrOp op,
+            OpAdaptor adaptor,
+            mlir::ConversionPatternRewriter &rewriter) const final {
+        if (op.getResult().getType().getDim() != 1) {
+            return mlir::failure();
+        }
+
+        mlir::Location loc = op.getLoc();
+        mlir::Value not_left = rewriter.create<ccirc::NotOp>(
+            loc, op.getLeft()).getResult();
+        mlir::Value not_right = rewriter.create<ccirc::NotOp>(
+            loc, op.getRight()).getResult();
+        mlir::Value and_result = rewriter.create<ccirc::AndOp>(
+            loc, not_left, not_right).getResult();
+        rewriter.replaceOpWithNewOp<ccirc::NotOp>(op, and_result);
+        return mlir::success();
+    }
+};
+
+// Decompose single-bit XOR into parity:
+// xor(a, b) = parity(a, b)
+struct DecomposeXorToParity
+        : public mlir::OpConversionPattern<ccirc::XorOp> {
+    using mlir::OpConversionPattern<ccirc::XorOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(
+            ccirc::XorOp op,
+            OpAdaptor adaptor,
+            mlir::ConversionPatternRewriter &rewriter) const final {
+        if (op.getResult().getType().getDim() != 1) {
+            return mlir::failure();
+        }
+
+        mlir::Location loc = op.getLoc();
+        llvm::SmallVector<mlir::Value> operands = {op.getLeft(), op.getRight()};
+        rewriter.replaceOpWithNewOp<ccirc::ParityOp>(
+            op, op.getResult().getType(), operands);
+        return mlir::success();
+    }
+};
+
 struct CCircToXAGConversionPass
         : public ccirc::CCircToXAGConversionBase<CCircToXAGConversionPass> {
     void runOnOperation() override {
@@ -85,7 +292,7 @@ struct CCircToXAGConversionPass
                                      ccirc::ParityOp,
                                      ccirc::ConstantOp>(
             [](mlir::Operation *op) {
-                if (op->getNumResults() == 1) {
+                if (op->getNumResults() != 1) {
                     return false;
                 }
                 if (ccirc::WireType res_ty = llvm::dyn_cast<ccirc::WireType>(op->getResult(0).getType())) {
@@ -97,7 +304,14 @@ struct CCircToXAGConversionPass
 
         mlir::RewritePatternSet patterns(&getContext());
         ccirc::populateSynthConversionPatterns(patterns);
-        patterns.add<SplitMultiBitConstant>(&getContext());
+        patterns.add<SplitMultiBitConstant,
+                     SplitMultiBitAnd,
+                     SplitMultiBitNot,
+                     SplitMultiBitParity,
+                     SplitMultiBitOr,
+                     SplitMultiBitXor,
+                     DecomposeOrToDeMorgan,
+                     DecomposeXorToParity>(&getContext());
 
         if (mlir::failed(mlir::applyFullConversion(circ, target, std::move(patterns)))) {
             signalPassFailure();

--- a/qwerty_mlir/tests/CCirc/Transforms/convert-ccirc-to-xag.mlir
+++ b/qwerty_mlir/tests/CCirc/Transforms/convert-ccirc-to-xag.mlir
@@ -1,5 +1,17 @@
 // RUN: qwerty-opt -convert-ccirc-to-xag -split-input-file %s | FileCheck %s
 
+// Single-bit Constant test
+// CHECK-LABEL: ccirc.circuit @single_bit_constant() irrev {
+//  CHECK-NEXT:   %0 = ccirc.constant true : !ccirc<wire[1]>
+//  CHECK-NEXT:   ccirc.return %0 : !ccirc<wire[1]>
+//  CHECK-NEXT: }
+ccirc.circuit @single_bit_constant() irrev {
+  %0 = ccirc.constant true : !ccirc<wire[1]>
+  ccirc.return %0 : !ccirc<wire[1]>
+}
+
+// -----
+
 // Single-bit XOR test
 // CHECK-LABEL: ccirc.circuit @single_bit_xor(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
 //  CHECK-NEXT:   %0 = ccirc.parity(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
@@ -35,6 +47,21 @@ ccirc.circuit @single_bit_or(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irr
 ccirc.circuit @single_bit_and(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
   %0 = ccirc.and(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
   ccirc.return %0 : !ccirc<wire[1]>
+}
+
+// -----
+
+// Multi-bit Constant (5 = 0b101) test
+// CHECK-LABEL: ccirc.circuit @multi_bit_constant() irrev {
+//  CHECK-NEXT:   %0 = ccirc.constant true : !ccirc<wire[1]>
+//  CHECK-NEXT:   %1 = ccirc.constant false : !ccirc<wire[1]>
+//  CHECK-NEXT:   %2 = ccirc.constant true : !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.wirepack(%0, %1, %2) : (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[3]>
+//  CHECK-NEXT:   ccirc.return %3 : !ccirc<wire[3]>
+//  CHECK-NEXT: }
+ccirc.circuit @multi_bit_constant() irrev {
+  %0 = ccirc.constant 5 : i3 : !ccirc<wire[3]>
+  ccirc.return %0 : !ccirc<wire[3]>
 }
 
 // -----
@@ -149,4 +176,68 @@ ccirc.circuit private @foo_0(%arg0: !ccirc<wire[3]>, %arg1: !ccirc<wire[3]>, %ar
   %2 = ccirc.constant 1 : i3 : !ccirc<wire[3]>
   %3 = ccirc.or(%1, %2) : (!ccirc<wire[3]>, !ccirc<wire[3]>) -> !ccirc<wire[3]>
   ccirc.return %3 : !ccirc<wire[3]>
+}
+
+// -----
+
+// Single-bit NOT is already legal — passes through unchanged.
+// CHECK-LABEL: ccirc.circuit @single_bit_not(%arg0: !ccirc<wire[1]>) irrev {
+//  CHECK-NEXT:   %0 = ccirc.not(%arg0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   ccirc.return %0 : !ccirc<wire[1]>
+//  CHECK-NEXT: }
+ccirc.circuit @single_bit_not(%arg0: !ccirc<wire[1]>) irrev {
+  %0 = ccirc.not(%arg0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+  ccirc.return %0 : !ccirc<wire[1]>
+}
+
+// -----
+
+// not(xor(a, b)) test
+// CHECK-LABEL: ccirc.circuit @not_of_xor(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+//  CHECK-NEXT:   %0 = ccirc.parity(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %1 = ccirc.not(%0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   ccirc.return %1 : !ccirc<wire[1]>
+//  CHECK-NEXT: }
+ccirc.circuit @not_of_xor(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+  %0 = ccirc.xor(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  %1 = ccirc.not(%0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+  ccirc.return %1 : !ccirc<wire[1]>
+}
+
+// -----
+
+// or(and(a, b), and(c, d)) test
+// CHECK-LABEL: ccirc.circuit @or_of_and(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>, %arg2: !ccirc<wire[1]>, %arg3: !ccirc<wire[1]>) irrev {
+//  CHECK-NEXT:   %0 = ccirc.and(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %1 = ccirc.and(%arg2, %arg3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %2 = ccirc.not(%0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.not(%1) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %4 = ccirc.and(%2, %3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %5 = ccirc.not(%4) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   ccirc.return %5 : !ccirc<wire[1]>
+//  CHECK-NEXT: }
+ccirc.circuit @or_of_and(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>, %arg2: !ccirc<wire[1]>, %arg3: !ccirc<wire[1]>) irrev {
+  %0 = ccirc.and(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  %1 = ccirc.and(%arg2, %arg3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  %2 = ccirc.or(%0, %1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  ccirc.return %2 : !ccirc<wire[1]>
+}
+
+// -----
+
+// and(xor(a, b), or(c, d)) test
+// CHECK-LABEL: ccirc.circuit @and_of_xor_or(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>, %arg2: !ccirc<wire[1]>, %arg3: !ccirc<wire[1]>) irrev {
+//  CHECK-NEXT:   %0 = ccirc.parity(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %1 = ccirc.not(%arg2) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %2 = ccirc.not(%arg3) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.and(%1, %2) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %4 = ccirc.not(%3) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %5 = ccirc.and(%0, %4) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   ccirc.return %5 : !ccirc<wire[1]>
+//  CHECK-NEXT: }
+ccirc.circuit @and_of_xor_or(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>, %arg2: !ccirc<wire[1]>, %arg3: !ccirc<wire[1]>) irrev {
+  %0 = ccirc.xor(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  %1 = ccirc.or(%arg2, %arg3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  %2 = ccirc.and(%0, %1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  ccirc.return %2 : !ccirc<wire[1]>
 }

--- a/qwerty_mlir/tests/CCirc/Transforms/convert-ccirc-to-xag.mlir
+++ b/qwerty_mlir/tests/CCirc/Transforms/convert-ccirc-to-xag.mlir
@@ -1,30 +1,45 @@
 // RUN: qwerty-opt -convert-ccirc-to-xag -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: ccirc.circuit @xor_to_parity(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+// Single-bit XOR test
+// CHECK-LABEL: ccirc.circuit @single_bit_xor(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
 //  CHECK-NEXT:   %0 = ccirc.parity(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
 //  CHECK-NEXT:   ccirc.return %0 : !ccirc<wire[1]>
 //  CHECK-NEXT: }
-ccirc.circuit @xor_to_parity(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+ccirc.circuit @single_bit_xor(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
   %0 = ccirc.xor(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
   ccirc.return %0 : !ccirc<wire[1]>
 }
 
 // -----
 
-// CHECK-LABEL: ccirc.circuit @or_to_demorgan(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+// Single-bit OR test
+// CHECK-LABEL: ccirc.circuit @single_bit_or(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
 //  CHECK-NEXT:   %0 = ccirc.not(%arg0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
 //  CHECK-NEXT:   %1 = ccirc.not(%arg1) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
 //  CHECK-NEXT:   %2 = ccirc.and(%0, %1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
 //  CHECK-NEXT:   %3 = ccirc.not(%2) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
 //  CHECK-NEXT:   ccirc.return %3 : !ccirc<wire[1]>
 //  CHECK-NEXT: }
-ccirc.circuit @or_to_demorgan(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+ccirc.circuit @single_bit_or(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
   %0 = ccirc.or(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
   ccirc.return %0 : !ccirc<wire[1]>
 }
 
 // -----
 
+// Single-bit AND test
+// CHECK-LABEL: ccirc.circuit @single_bit_and(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+//  CHECK-NEXT:   %0 = ccirc.and(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   ccirc.return %0 : !ccirc<wire[1]>
+//  CHECK-NEXT: }
+ccirc.circuit @single_bit_and(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+  %0 = ccirc.and(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  ccirc.return %0 : !ccirc<wire[1]>
+}
+
+// -----
+
+// Multi-bit NOT test
 // CHECK-LABEL: ccirc.circuit @multi_bit_not(%arg0: !ccirc<wire[2]>) irrev {
 //  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
 //  CHECK-NEXT:   %1 = ccirc.not(%0#0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
@@ -39,6 +54,7 @@ ccirc.circuit @multi_bit_not(%arg0: !ccirc<wire[2]>) irrev {
 
 // -----
 
+// Multi-bit AND test
 // CHECK-LABEL: ccirc.circuit @multi_bit_and(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
 //  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
 //  CHECK-NEXT:   %1:2 = ccirc.wireunpack %arg1 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
@@ -54,23 +70,7 @@ ccirc.circuit @multi_bit_and(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irr
 
 // -----
 
-// CHECK-LABEL: ccirc.circuit @multi_bit_parity(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
-//  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
-//  CHECK-NEXT:   %1:2 = ccirc.wireunpack %arg1 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
-//  CHECK-NEXT:   %2 = ccirc.parity(%0#0, %1#0) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
-//  CHECK-NEXT:   %3 = ccirc.parity(%0#1, %1#1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
-//  CHECK-NEXT:   %4 = ccirc.wirepack(%2, %3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[2]>
-//  CHECK-NEXT:   ccirc.return %4 : !ccirc<wire[2]>
-//  CHECK-NEXT: }
-ccirc.circuit @multi_bit_parity(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
-  %0 = ccirc.parity(%arg0, %arg1) : (!ccirc<wire[2]>, !ccirc<wire[2]>) -> !ccirc<wire[2]>
-  ccirc.return %0 : !ccirc<wire[2]>
-}
-
-// -----
-
-// Multi-bit XOR: split into element-wise XORs (Round One), then each
-// single-bit XOR becomes a parity (Round Two).
+// Multi-bit XOR test
 // CHECK-LABEL: ccirc.circuit @multi_bit_xor(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
 //  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
 //  CHECK-NEXT:   %1:2 = ccirc.wireunpack %arg1 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
@@ -86,8 +86,7 @@ ccirc.circuit @multi_bit_xor(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irr
 
 // -----
 
-// Multi-bit OR: split into element-wise ORs (Round One), then each
-// single-bit OR becomes not(and(not, not)) via De Morgan's law (Round Two).
+// Multi-bit OR test
 // CHECK-LABEL: ccirc.circuit @multi_bit_or(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
 //  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
 //  CHECK-NEXT:   %1:2 = ccirc.wireunpack %arg1 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
@@ -105,4 +104,49 @@ ccirc.circuit @multi_bit_xor(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irr
 ccirc.circuit @multi_bit_or(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
   %0 = ccirc.or(%arg0, %arg1) : (!ccirc<wire[2]>, !ccirc<wire[2]>) -> !ccirc<wire[2]>
   ccirc.return %0 : !ccirc<wire[2]>
+}
+
+// -----
+
+// Example from PR
+// CHECK-LABEL: ccirc.circuit private @foo_0(%arg0: !ccirc<wire[3]>, %arg1: !ccirc<wire[3]>, %arg2: !ccirc<wire[3]>) irrev {
+//  CHECK-NEXT:   %0:3 = ccirc.wireunpack %arg0 : (!ccirc<wire[3]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %1:3 = ccirc.wireunpack %arg1 : (!ccirc<wire[3]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %2 = ccirc.parity(%0#0, %1#0) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.parity(%0#1, %1#1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %4 = ccirc.parity(%0#2, %1#2) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %5 = ccirc.wirepack(%2, %3, %4) : (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[3]>
+//  CHECK-NEXT:   %6:3 = ccirc.wireunpack %5 : (!ccirc<wire[3]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %7:3 = ccirc.wireunpack %arg2 : (!ccirc<wire[3]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %8 = ccirc.parity(%6#0, %7#0) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %9 = ccirc.parity(%6#1, %7#1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %10 = ccirc.parity(%6#2, %7#2) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %11 = ccirc.wirepack(%8, %9, %10) : (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[3]>
+//  CHECK-NEXT:   %12 = ccirc.constant false : !ccirc<wire[1]>
+//  CHECK-NEXT:   %13 = ccirc.constant false : !ccirc<wire[1]>
+//  CHECK-NEXT:   %14 = ccirc.constant true : !ccirc<wire[1]>
+//  CHECK-NEXT:   %15 = ccirc.wirepack(%12, %13, %14) : (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[3]>
+//  CHECK-NEXT:   %16:3 = ccirc.wireunpack %11 : (!ccirc<wire[3]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %17:3 = ccirc.wireunpack %15 : (!ccirc<wire[3]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %18 = ccirc.not(%16#0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %19 = ccirc.not(%17#0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %20 = ccirc.and(%18, %19) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %21 = ccirc.not(%20) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %22 = ccirc.not(%16#1) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %23 = ccirc.not(%17#1) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %24 = ccirc.and(%22, %23) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %25 = ccirc.not(%24) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %26 = ccirc.not(%16#2) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %27 = ccirc.not(%17#2) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %28 = ccirc.and(%26, %27) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %29 = ccirc.not(%28) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %30 = ccirc.wirepack(%21, %25, %29) : (!ccirc<wire[1]>, !ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[3]>
+//  CHECK-NEXT:   ccirc.return %30 : !ccirc<wire[3]>
+//  CHECK-NEXT: }
+ccirc.circuit private @foo_0(%arg0: !ccirc<wire[3]>, %arg1: !ccirc<wire[3]>, %arg2: !ccirc<wire[3]>) irrev {
+  %0 = ccirc.xor(%arg0, %arg1) : (!ccirc<wire[3]>, !ccirc<wire[3]>) -> !ccirc<wire[3]>
+  %1 = ccirc.xor(%0, %arg2) : (!ccirc<wire[3]>, !ccirc<wire[3]>) -> !ccirc<wire[3]>
+  %2 = ccirc.constant 1 : i3 : !ccirc<wire[3]>
+  %3 = ccirc.or(%1, %2) : (!ccirc<wire[3]>, !ccirc<wire[3]>) -> !ccirc<wire[3]>
+  ccirc.return %3 : !ccirc<wire[3]>
 }

--- a/qwerty_mlir/tests/CCirc/Transforms/convert-ccirc-to-xag.mlir
+++ b/qwerty_mlir/tests/CCirc/Transforms/convert-ccirc-to-xag.mlir
@@ -1,0 +1,108 @@
+// RUN: qwerty-opt -convert-ccirc-to-xag -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: ccirc.circuit @xor_to_parity(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+//  CHECK-NEXT:   %0 = ccirc.parity(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   ccirc.return %0 : !ccirc<wire[1]>
+//  CHECK-NEXT: }
+ccirc.circuit @xor_to_parity(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+  %0 = ccirc.xor(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  ccirc.return %0 : !ccirc<wire[1]>
+}
+
+// -----
+
+// CHECK-LABEL: ccirc.circuit @or_to_demorgan(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+//  CHECK-NEXT:   %0 = ccirc.not(%arg0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %1 = ccirc.not(%arg1) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %2 = ccirc.and(%0, %1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.not(%2) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   ccirc.return %3 : !ccirc<wire[1]>
+//  CHECK-NEXT: }
+ccirc.circuit @or_to_demorgan(%arg0: !ccirc<wire[1]>, %arg1: !ccirc<wire[1]>) irrev {
+  %0 = ccirc.or(%arg0, %arg1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+  ccirc.return %0 : !ccirc<wire[1]>
+}
+
+// -----
+
+// CHECK-LABEL: ccirc.circuit @multi_bit_not(%arg0: !ccirc<wire[2]>) irrev {
+//  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %1 = ccirc.not(%0#0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %2 = ccirc.not(%0#1) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.wirepack(%1, %2) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[2]>
+//  CHECK-NEXT:   ccirc.return %3 : !ccirc<wire[2]>
+//  CHECK-NEXT: }
+ccirc.circuit @multi_bit_not(%arg0: !ccirc<wire[2]>) irrev {
+  %0 = ccirc.not(%arg0) : (!ccirc<wire[2]>) -> !ccirc<wire[2]>
+  ccirc.return %0 : !ccirc<wire[2]>
+}
+
+// -----
+
+// CHECK-LABEL: ccirc.circuit @multi_bit_and(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
+//  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %1:2 = ccirc.wireunpack %arg1 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %2 = ccirc.and(%0#0, %1#0) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.and(%0#1, %1#1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %4 = ccirc.wirepack(%2, %3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[2]>
+//  CHECK-NEXT:   ccirc.return %4 : !ccirc<wire[2]>
+//  CHECK-NEXT: }
+ccirc.circuit @multi_bit_and(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
+  %0 = ccirc.and(%arg0, %arg1) : (!ccirc<wire[2]>, !ccirc<wire[2]>) -> !ccirc<wire[2]>
+  ccirc.return %0 : !ccirc<wire[2]>
+}
+
+// -----
+
+// CHECK-LABEL: ccirc.circuit @multi_bit_parity(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
+//  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %1:2 = ccirc.wireunpack %arg1 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %2 = ccirc.parity(%0#0, %1#0) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.parity(%0#1, %1#1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %4 = ccirc.wirepack(%2, %3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[2]>
+//  CHECK-NEXT:   ccirc.return %4 : !ccirc<wire[2]>
+//  CHECK-NEXT: }
+ccirc.circuit @multi_bit_parity(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
+  %0 = ccirc.parity(%arg0, %arg1) : (!ccirc<wire[2]>, !ccirc<wire[2]>) -> !ccirc<wire[2]>
+  ccirc.return %0 : !ccirc<wire[2]>
+}
+
+// -----
+
+// Multi-bit XOR: split into element-wise XORs (Round One), then each
+// single-bit XOR becomes a parity (Round Two).
+// CHECK-LABEL: ccirc.circuit @multi_bit_xor(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
+//  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %1:2 = ccirc.wireunpack %arg1 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %2 = ccirc.parity(%0#0, %1#0) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.parity(%0#1, %1#1) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %4 = ccirc.wirepack(%2, %3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[2]>
+//  CHECK-NEXT:   ccirc.return %4 : !ccirc<wire[2]>
+//  CHECK-NEXT: }
+ccirc.circuit @multi_bit_xor(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
+  %0 = ccirc.xor(%arg0, %arg1) : (!ccirc<wire[2]>, !ccirc<wire[2]>) -> !ccirc<wire[2]>
+  ccirc.return %0 : !ccirc<wire[2]>
+}
+
+// -----
+
+// Multi-bit OR: split into element-wise ORs (Round One), then each
+// single-bit OR becomes not(and(not, not)) via De Morgan's law (Round Two).
+// CHECK-LABEL: ccirc.circuit @multi_bit_or(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
+//  CHECK-NEXT:   %0:2 = ccirc.wireunpack %arg0 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %1:2 = ccirc.wireunpack %arg1 : (!ccirc<wire[2]>) -> (!ccirc<wire[1]>, !ccirc<wire[1]>)
+//  CHECK-NEXT:   %2 = ccirc.not(%0#0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %3 = ccirc.not(%1#0) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %4 = ccirc.and(%2, %3) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %5 = ccirc.not(%4) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %6 = ccirc.not(%0#1) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %7 = ccirc.not(%1#1) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %8 = ccirc.and(%6, %7) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %9 = ccirc.not(%8) : (!ccirc<wire[1]>) -> !ccirc<wire[1]>
+//  CHECK-NEXT:   %10 = ccirc.wirepack(%5, %9) : (!ccirc<wire[1]>, !ccirc<wire[1]>) -> !ccirc<wire[2]>
+//  CHECK-NEXT:   ccirc.return %10 : !ccirc<wire[2]>
+//  CHECK-NEXT: }
+ccirc.circuit @multi_bit_or(%arg0: !ccirc<wire[2]>, %arg1: !ccirc<wire[2]>) irrev {
+  %0 = ccirc.or(%arg0, %arg1) : (!ccirc<wire[2]>, !ccirc<wire[2]>) -> !ccirc<wire[2]>
+  ccirc.return %0 : !ccirc<wire[2]>
+}


### PR DESCRIPTION
This PR implements the CCircToXAGConversionPass such that it coverts CCirc into an XAG. It follows a two-phase pass where the first phase converts all logic ops into single-bit versions alongside wire structural ops. The second phase converts illegal single-bit logical ops into legal logical ops through DeMorgan's law or parity ones.