### PR TITLE
feat(ccirc): add sub op

### DIFF
--- a/qwerty_mlir/include/CCirc/IR/CCircOps.td
+++ b/qwerty_mlir/include/CCirc/IR/CCircOps.td
@@ -152,6 +152,14 @@ def CCirc_AddOp : CCirc_Op<"add", [Pure, InferTypeOpAdaptor]> {
     let hasVerifier = 1;
 }
 
+def CCirc_SubOp : CCirc_Op<"sub", [Pure, InferTypeOpAdaptor]> {
+    let summary = "Subtract two wire bundles";
+    let arguments = (ins CCirc_Wire:$a, CCirc_Wire:$b);
+    let results = (outs CCirc_Wire:$diff);
+    let assemblyFormat = "`(` $a `,` $b `)` attr-dict `:` functional-type(operands, results)";
+    let hasVerifier = 1;
+}
+
 def CCirc_ModMulOp : CCirc_Op<"modmul", [Pure, InferTypeOpAdaptor]> {
     let summary = "Modular multiplier";
     let description = [{

--- a/qwerty_mlir/include/CCirc/Synth/CCircSynth.h
+++ b/qwerty_mlir/include/CCirc/Synth/CCircSynth.h
@@ -48,6 +48,14 @@ void synthAdd(
         llvm::SmallVectorImpl<mlir::Value> &wires_b,
         llvm::SmallVectorImpl<mlir::Value> &wires_sum);
 
+// Synthesize classical circuitry that achieves a - b.
+void synthSub(
+        mlir::OpBuilder &builder,
+        mlir::Location loc,
+        llvm::SmallVectorImpl<mlir::Value> &wires_a,
+        llvm::SmallVectorImpl<mlir::Value> &wires_b,
+        llvm::SmallVectorImpl<mlir::Value> &wires_diff);
+
 // Synthesize classical circuitry that achieves X * y % N, where X and N are
 // constants.
 void synthModMul(

--- a/qwerty_mlir/lib/CCirc/IR/CCircOps.cpp
+++ b/qwerty_mlir/lib/CCirc/IR/CCircOps.cpp
@@ -927,6 +927,25 @@ mlir::LogicalResult AddOp::inferReturnTypes(
     return mlir::success();
 }
 
+mlir::LogicalResult SubOp::verify() {
+    if (getA().getType() != getB().getType()) {
+        return emitOpError("Both input wire sizes do not match");
+    }
+    if (getA().getType() != getDiff().getType()) {
+        return emitOpError("Input and output wire sizes do not match");
+    }
+    return mlir::success();
+}
+
+mlir::LogicalResult SubOp::inferReturnTypes(
+        mlir::MLIRContext *ctx,
+        std::optional<mlir::Location> loc,
+        SubOp::Adaptor adaptor,
+        llvm::SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
+    inferredReturnTypes.push_back(adaptor.getA().getType());
+    return mlir::success();
+}
+
 mlir::LogicalResult ModMulOp::verify() {
     if (getY().getType() != getProduct().getType()) {
         return emitOpError("Input and output wire sizes do not match");

--- a/qwerty_mlir/lib/CCirc/Synth/SynthArith.cpp
+++ b/qwerty_mlir/lib/CCirc/Synth/SynthArith.cpp
@@ -62,6 +62,22 @@ void synthAdd(
     fullAdderN(builder, loc, wires_a, wires_b, zero, wires_sum);
 }
 
+void synthSub(
+        mlir::OpBuilder &builder,
+        mlir::Location loc,
+        llvm::SmallVectorImpl<mlir::Value> &wires_a,
+        llvm::SmallVectorImpl<mlir::Value> &wires_b,
+        llvm::SmallVectorImpl<mlir::Value> &wires_diff) {
+    // Two's complement: a - b = a + ~b + 1
+    llvm::SmallVector<mlir::Value> wires_not_b;
+    for (mlir::Value b : wires_b) {
+        wires_not_b.push_back(ccirc::NotOp::create(builder, loc, b).getResult());
+    }
+    mlir::Value one = ccirc::ConstantOp::create(builder,
+        loc, llvm::APInt(/*numBits=*/1, /*val=*/1)).getResult();
+    fullAdderN(builder, loc, wires_a, wires_not_b, one, wires_diff);
+}
+
 void synthModMul(
         mlir::OpBuilder &builder,
         mlir::Location loc,

--- a/qwerty_mlir/lib/CCirc/Transforms/SynthConversionPatterns.cpp
+++ b/qwerty_mlir/lib/CCirc/Transforms/SynthConversionPatterns.cpp
@@ -83,6 +83,29 @@ struct DecomposeAdd
     }
 };
 
+struct DecomposeSub
+        : public mlir::OpConversionPattern<ccirc::SubOp> {
+    using mlir::OpConversionPattern<ccirc::SubOp>::OpConversionPattern;
+
+    mlir::LogicalResult matchAndRewrite(
+            ccirc::SubOp sub,
+            OpAdaptor adaptor,
+            mlir::ConversionPatternRewriter &rewriter) const final {
+        mlir::Location loc = sub.getLoc();
+
+        llvm::SmallVector<mlir::Value> wires_a(ccirc::WireUnpackOp::create(rewriter,
+            loc, sub.getA()).getWires());
+        llvm::SmallVector<mlir::Value> wires_b(ccirc::WireUnpackOp::create(rewriter,
+            loc, sub.getB()).getWires());
+
+        llvm::SmallVector<mlir::Value> wires_diff;
+        ccirc::synthSub(rewriter, loc, wires_a, wires_b, wires_diff);
+
+        rewriter.replaceOpWithNewOp<ccirc::WirePackOp>(sub, wires_diff);
+        return mlir::success();
+    }
+};
+
 struct DecomposeModMul
         : public mlir::OpConversionPattern<ccirc::ModMulOp> {
     using mlir::OpConversionPattern<ccirc::ModMulOp>::OpConversionPattern;
@@ -132,5 +155,6 @@ void ccirc::populateSynthConversionPatterns(
     patterns.add<DecomposeRotateLeft,
                  DecomposeRotateRight,
                  DecomposeAdd,
+                 DecomposeSub,
                  DecomposeModMul>(patterns.getContext());
 }

--- a/qwerty_mlir/tests/CCirc/IR/parsing.mlir
+++ b/qwerty_mlir/tests/CCirc/IR/parsing.mlir
@@ -31,3 +31,12 @@ ccirc.circuit @add(%arg0: !ccirc<wire[4]>, %arg1: !ccirc<wire[4]>) irrev {
   %0 = ccirc.add(%arg0, %arg1) : (!ccirc<wire[4]>, !ccirc<wire[4]>) -> !ccirc<wire[4]>
   ccirc.return %0 : !ccirc<wire[4]>
 }
+
+// CHECK-LABEL: ccirc.circuit @sub(%arg0: !ccirc<wire[4]>, %arg1: !ccirc<wire[4]>) irrev {
+//  CHECK-NEXT:   %0 = ccirc.sub(%arg0, %arg1) : (!ccirc<wire[4]>, !ccirc<wire[4]>) -> !ccirc<wire[4]>
+//  CHECK-NEXT:   ccirc.return %0 : !ccirc<wire[4]>
+//  CHECK-NEXT: }
+ccirc.circuit @sub(%arg0: !ccirc<wire[4]>, %arg1: !ccirc<wire[4]>) irrev {
+  %0 = ccirc.sub(%arg0, %arg1) : (!ccirc<wire[4]>, !ccirc<wire[4]>) -> !ccirc<wire[4]>
+  ccirc.return %0 : !ccirc<wire[4]>
+}

--- a/qwerty_mlir/tests/CCirc/Synth/gen-arith-tests.py
+++ b/qwerty_mlir/tests/CCirc/Synth/gen-arith-tests.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 """
-Generates ``synth-arith.mlir``, a FileCheck test that tests an 4-bit adder on
-all possible inputs.
+Generates ``synth-arith.mlir``, a FileCheck test that tests an 4-bit adder and
+an 4-bit subtractor on all possible inputs.
 """
 
 import os
@@ -22,8 +22,20 @@ ccirc.circuit @add(%a: !ccirc<wire[{N_BITS}]>, %b: !ccirc<wire[{N_BITS}]>) irrev
     ccirc.return %0 : !ccirc<wire[{N_BITS}]>
 }}
 
+ccirc.circuit @sub(%a: !ccirc<wire[{N_BITS}]>, %b: !ccirc<wire[{N_BITS}]>) irrev {{
+    %0 = ccirc.sub(%a, %b) : (!ccirc<wire[{N_BITS}]>, !ccirc<wire[{N_BITS}]>) -> !ccirc<wire[{N_BITS}]>
+    ccirc.return %0 : !ccirc<wire[{N_BITS}]>
+}}
+
 func.func @check_add(%a: i{N_BITS}, %b: i{N_BITS}) -> () {{
     %func = ccirc.func_ptr @add : (i{N_BITS}, i{N_BITS}) -> (i{N_BITS})
+    %res = func.call_indirect %func(%a, %b) : (i{N_BITS}, i{N_BITS}) -> (i{N_BITS})
+    vector.print %res : i{N_BITS}
+    return
+}}
+
+func.func @check_sub(%a: i{N_BITS}, %b: i{N_BITS}) -> () {{
+    %func = ccirc.func_ptr @sub : (i{N_BITS}, i{N_BITS}) -> (i{N_BITS})
     %res = func.call_indirect %func(%a, %b) : (i{N_BITS}, i{N_BITS}) -> (i{N_BITS})
     vector.print %res : i{N_BITS}
     return
@@ -40,13 +52,26 @@ EPILOGUE = """
 def format_constant(c):
     return f"    %c{c} = arith.constant {c} : i{N_BITS}\n"
 
-def format_test(c1, c2):
+def to_signed(val):
+    val &= (1 << N_BITS) - 1
+    return val if val < (1 << (N_BITS - 1)) else val | (-1 << N_BITS)
+
+def format_add_test(c1, c2):
     sum = (c1 + c2) & ((1 << N_BITS) - 1)
-    res = sum if sum < (1 << (N_BITS - 1)) else sum | (-1 << N_BITS)
+    res = to_signed(sum)
     return f"""
     // 0x{c1:02x} + 0x{c2:02x} = 0x{sum:02x}
     // CHECK: {res}
     func.call @check_add(%c{c1}, %c{c2}) : (i{N_BITS}, i{N_BITS}) -> ()
+"""
+
+def format_sub_test(c1, c2):
+    diff = (c1 - c2) & ((1 << N_BITS) - 1)
+    res = to_signed(diff)
+    return f"""
+    // 0x{c1:02x} - 0x{c2:02x} = 0x{diff:02x}
+    // CHECK: {res}
+    func.call @check_sub(%c{c1}, %c{c2}) : (i{N_BITS}, i{N_BITS}) -> ()
 """
 
 def main():
@@ -58,7 +83,11 @@ def main():
 
         for c1 in range(1 << N_BITS):
             for c2 in range(1 << N_BITS):
-                fp.write(format_test(c1, c2))
+                fp.write(format_add_test(c1, c2))
+
+        for c1 in range(1 << N_BITS):
+            for c2 in range(1 << N_BITS):
+                fp.write(format_sub_test(c1, c2))
 
         fp.write(EPILOGUE)
 

--- a/qwerty_mlir/tests/CCirc/Synth/synth-arith.mlir
+++ b/qwerty_mlir/tests/CCirc/Synth/synth-arith.mlir
@@ -8,8 +8,20 @@ ccirc.circuit @add(%a: !ccirc<wire[4]>, %b: !ccirc<wire[4]>) irrev {
     ccirc.return %0 : !ccirc<wire[4]>
 }
 
+ccirc.circuit @sub(%a: !ccirc<wire[4]>, %b: !ccirc<wire[4]>) irrev {
+    %0 = ccirc.sub(%a, %b) : (!ccirc<wire[4]>, !ccirc<wire[4]>) -> !ccirc<wire[4]>
+    ccirc.return %0 : !ccirc<wire[4]>
+}
+
 func.func @check_add(%a: i4, %b: i4) -> () {
     %func = ccirc.func_ptr @add : (i4, i4) -> (i4)
+    %res = func.call_indirect %func(%a, %b) : (i4, i4) -> (i4)
+    vector.print %res : i4
+    return
+}
+
+func.func @check_sub(%a: i4, %b: i4) -> () {
+    %func = ccirc.func_ptr @sub : (i4, i4) -> (i4)
     %res = func.call_indirect %func(%a, %b) : (i4, i4) -> (i4)
     vector.print %res : i4
     return
@@ -1056,6 +1068,1030 @@ func.func @test() {
     // 0x0f + 0x0f = 0x0e
     // CHECK: -2
     func.call @check_add(%c15, %c15) : (i4, i4) -> ()
+
+    // 0x00 - 0x00 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c0, %c0) : (i4, i4) -> ()
+
+    // 0x00 - 0x01 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c0, %c1) : (i4, i4) -> ()
+
+    // 0x00 - 0x02 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c0, %c2) : (i4, i4) -> ()
+
+    // 0x00 - 0x03 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c0, %c3) : (i4, i4) -> ()
+
+    // 0x00 - 0x04 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c0, %c4) : (i4, i4) -> ()
+
+    // 0x00 - 0x05 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c0, %c5) : (i4, i4) -> ()
+
+    // 0x00 - 0x06 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c0, %c6) : (i4, i4) -> ()
+
+    // 0x00 - 0x07 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c0, %c7) : (i4, i4) -> ()
+
+    // 0x00 - 0x08 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c0, %c8) : (i4, i4) -> ()
+
+    // 0x00 - 0x09 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c0, %c9) : (i4, i4) -> ()
+
+    // 0x00 - 0x0a = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c0, %c10) : (i4, i4) -> ()
+
+    // 0x00 - 0x0b = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c0, %c11) : (i4, i4) -> ()
+
+    // 0x00 - 0x0c = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c0, %c12) : (i4, i4) -> ()
+
+    // 0x00 - 0x0d = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c0, %c13) : (i4, i4) -> ()
+
+    // 0x00 - 0x0e = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c0, %c14) : (i4, i4) -> ()
+
+    // 0x00 - 0x0f = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c0, %c15) : (i4, i4) -> ()
+
+    // 0x01 - 0x00 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c1, %c0) : (i4, i4) -> ()
+
+    // 0x01 - 0x01 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c1, %c1) : (i4, i4) -> ()
+
+    // 0x01 - 0x02 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c1, %c2) : (i4, i4) -> ()
+
+    // 0x01 - 0x03 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c1, %c3) : (i4, i4) -> ()
+
+    // 0x01 - 0x04 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c1, %c4) : (i4, i4) -> ()
+
+    // 0x01 - 0x05 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c1, %c5) : (i4, i4) -> ()
+
+    // 0x01 - 0x06 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c1, %c6) : (i4, i4) -> ()
+
+    // 0x01 - 0x07 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c1, %c7) : (i4, i4) -> ()
+
+    // 0x01 - 0x08 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c1, %c8) : (i4, i4) -> ()
+
+    // 0x01 - 0x09 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c1, %c9) : (i4, i4) -> ()
+
+    // 0x01 - 0x0a = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c1, %c10) : (i4, i4) -> ()
+
+    // 0x01 - 0x0b = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c1, %c11) : (i4, i4) -> ()
+
+    // 0x01 - 0x0c = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c1, %c12) : (i4, i4) -> ()
+
+    // 0x01 - 0x0d = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c1, %c13) : (i4, i4) -> ()
+
+    // 0x01 - 0x0e = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c1, %c14) : (i4, i4) -> ()
+
+    // 0x01 - 0x0f = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c1, %c15) : (i4, i4) -> ()
+
+    // 0x02 - 0x00 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c2, %c0) : (i4, i4) -> ()
+
+    // 0x02 - 0x01 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c2, %c1) : (i4, i4) -> ()
+
+    // 0x02 - 0x02 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c2, %c2) : (i4, i4) -> ()
+
+    // 0x02 - 0x03 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c2, %c3) : (i4, i4) -> ()
+
+    // 0x02 - 0x04 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c2, %c4) : (i4, i4) -> ()
+
+    // 0x02 - 0x05 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c2, %c5) : (i4, i4) -> ()
+
+    // 0x02 - 0x06 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c2, %c6) : (i4, i4) -> ()
+
+    // 0x02 - 0x07 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c2, %c7) : (i4, i4) -> ()
+
+    // 0x02 - 0x08 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c2, %c8) : (i4, i4) -> ()
+
+    // 0x02 - 0x09 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c2, %c9) : (i4, i4) -> ()
+
+    // 0x02 - 0x0a = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c2, %c10) : (i4, i4) -> ()
+
+    // 0x02 - 0x0b = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c2, %c11) : (i4, i4) -> ()
+
+    // 0x02 - 0x0c = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c2, %c12) : (i4, i4) -> ()
+
+    // 0x02 - 0x0d = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c2, %c13) : (i4, i4) -> ()
+
+    // 0x02 - 0x0e = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c2, %c14) : (i4, i4) -> ()
+
+    // 0x02 - 0x0f = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c2, %c15) : (i4, i4) -> ()
+
+    // 0x03 - 0x00 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c3, %c0) : (i4, i4) -> ()
+
+    // 0x03 - 0x01 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c3, %c1) : (i4, i4) -> ()
+
+    // 0x03 - 0x02 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c3, %c2) : (i4, i4) -> ()
+
+    // 0x03 - 0x03 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c3, %c3) : (i4, i4) -> ()
+
+    // 0x03 - 0x04 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c3, %c4) : (i4, i4) -> ()
+
+    // 0x03 - 0x05 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c3, %c5) : (i4, i4) -> ()
+
+    // 0x03 - 0x06 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c3, %c6) : (i4, i4) -> ()
+
+    // 0x03 - 0x07 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c3, %c7) : (i4, i4) -> ()
+
+    // 0x03 - 0x08 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c3, %c8) : (i4, i4) -> ()
+
+    // 0x03 - 0x09 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c3, %c9) : (i4, i4) -> ()
+
+    // 0x03 - 0x0a = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c3, %c10) : (i4, i4) -> ()
+
+    // 0x03 - 0x0b = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c3, %c11) : (i4, i4) -> ()
+
+    // 0x03 - 0x0c = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c3, %c12) : (i4, i4) -> ()
+
+    // 0x03 - 0x0d = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c3, %c13) : (i4, i4) -> ()
+
+    // 0x03 - 0x0e = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c3, %c14) : (i4, i4) -> ()
+
+    // 0x03 - 0x0f = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c3, %c15) : (i4, i4) -> ()
+
+    // 0x04 - 0x00 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c4, %c0) : (i4, i4) -> ()
+
+    // 0x04 - 0x01 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c4, %c1) : (i4, i4) -> ()
+
+    // 0x04 - 0x02 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c4, %c2) : (i4, i4) -> ()
+
+    // 0x04 - 0x03 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c4, %c3) : (i4, i4) -> ()
+
+    // 0x04 - 0x04 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c4, %c4) : (i4, i4) -> ()
+
+    // 0x04 - 0x05 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c4, %c5) : (i4, i4) -> ()
+
+    // 0x04 - 0x06 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c4, %c6) : (i4, i4) -> ()
+
+    // 0x04 - 0x07 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c4, %c7) : (i4, i4) -> ()
+
+    // 0x04 - 0x08 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c4, %c8) : (i4, i4) -> ()
+
+    // 0x04 - 0x09 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c4, %c9) : (i4, i4) -> ()
+
+    // 0x04 - 0x0a = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c4, %c10) : (i4, i4) -> ()
+
+    // 0x04 - 0x0b = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c4, %c11) : (i4, i4) -> ()
+
+    // 0x04 - 0x0c = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c4, %c12) : (i4, i4) -> ()
+
+    // 0x04 - 0x0d = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c4, %c13) : (i4, i4) -> ()
+
+    // 0x04 - 0x0e = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c4, %c14) : (i4, i4) -> ()
+
+    // 0x04 - 0x0f = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c4, %c15) : (i4, i4) -> ()
+
+    // 0x05 - 0x00 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c5, %c0) : (i4, i4) -> ()
+
+    // 0x05 - 0x01 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c5, %c1) : (i4, i4) -> ()
+
+    // 0x05 - 0x02 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c5, %c2) : (i4, i4) -> ()
+
+    // 0x05 - 0x03 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c5, %c3) : (i4, i4) -> ()
+
+    // 0x05 - 0x04 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c5, %c4) : (i4, i4) -> ()
+
+    // 0x05 - 0x05 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c5, %c5) : (i4, i4) -> ()
+
+    // 0x05 - 0x06 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c5, %c6) : (i4, i4) -> ()
+
+    // 0x05 - 0x07 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c5, %c7) : (i4, i4) -> ()
+
+    // 0x05 - 0x08 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c5, %c8) : (i4, i4) -> ()
+
+    // 0x05 - 0x09 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c5, %c9) : (i4, i4) -> ()
+
+    // 0x05 - 0x0a = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c5, %c10) : (i4, i4) -> ()
+
+    // 0x05 - 0x0b = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c5, %c11) : (i4, i4) -> ()
+
+    // 0x05 - 0x0c = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c5, %c12) : (i4, i4) -> ()
+
+    // 0x05 - 0x0d = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c5, %c13) : (i4, i4) -> ()
+
+    // 0x05 - 0x0e = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c5, %c14) : (i4, i4) -> ()
+
+    // 0x05 - 0x0f = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c5, %c15) : (i4, i4) -> ()
+
+    // 0x06 - 0x00 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c6, %c0) : (i4, i4) -> ()
+
+    // 0x06 - 0x01 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c6, %c1) : (i4, i4) -> ()
+
+    // 0x06 - 0x02 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c6, %c2) : (i4, i4) -> ()
+
+    // 0x06 - 0x03 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c6, %c3) : (i4, i4) -> ()
+
+    // 0x06 - 0x04 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c6, %c4) : (i4, i4) -> ()
+
+    // 0x06 - 0x05 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c6, %c5) : (i4, i4) -> ()
+
+    // 0x06 - 0x06 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c6, %c6) : (i4, i4) -> ()
+
+    // 0x06 - 0x07 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c6, %c7) : (i4, i4) -> ()
+
+    // 0x06 - 0x08 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c6, %c8) : (i4, i4) -> ()
+
+    // 0x06 - 0x09 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c6, %c9) : (i4, i4) -> ()
+
+    // 0x06 - 0x0a = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c6, %c10) : (i4, i4) -> ()
+
+    // 0x06 - 0x0b = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c6, %c11) : (i4, i4) -> ()
+
+    // 0x06 - 0x0c = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c6, %c12) : (i4, i4) -> ()
+
+    // 0x06 - 0x0d = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c6, %c13) : (i4, i4) -> ()
+
+    // 0x06 - 0x0e = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c6, %c14) : (i4, i4) -> ()
+
+    // 0x06 - 0x0f = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c6, %c15) : (i4, i4) -> ()
+
+    // 0x07 - 0x00 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c7, %c0) : (i4, i4) -> ()
+
+    // 0x07 - 0x01 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c7, %c1) : (i4, i4) -> ()
+
+    // 0x07 - 0x02 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c7, %c2) : (i4, i4) -> ()
+
+    // 0x07 - 0x03 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c7, %c3) : (i4, i4) -> ()
+
+    // 0x07 - 0x04 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c7, %c4) : (i4, i4) -> ()
+
+    // 0x07 - 0x05 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c7, %c5) : (i4, i4) -> ()
+
+    // 0x07 - 0x06 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c7, %c6) : (i4, i4) -> ()
+
+    // 0x07 - 0x07 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c7, %c7) : (i4, i4) -> ()
+
+    // 0x07 - 0x08 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c7, %c8) : (i4, i4) -> ()
+
+    // 0x07 - 0x09 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c7, %c9) : (i4, i4) -> ()
+
+    // 0x07 - 0x0a = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c7, %c10) : (i4, i4) -> ()
+
+    // 0x07 - 0x0b = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c7, %c11) : (i4, i4) -> ()
+
+    // 0x07 - 0x0c = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c7, %c12) : (i4, i4) -> ()
+
+    // 0x07 - 0x0d = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c7, %c13) : (i4, i4) -> ()
+
+    // 0x07 - 0x0e = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c7, %c14) : (i4, i4) -> ()
+
+    // 0x07 - 0x0f = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c7, %c15) : (i4, i4) -> ()
+
+    // 0x08 - 0x00 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c8, %c0) : (i4, i4) -> ()
+
+    // 0x08 - 0x01 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c8, %c1) : (i4, i4) -> ()
+
+    // 0x08 - 0x02 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c8, %c2) : (i4, i4) -> ()
+
+    // 0x08 - 0x03 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c8, %c3) : (i4, i4) -> ()
+
+    // 0x08 - 0x04 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c8, %c4) : (i4, i4) -> ()
+
+    // 0x08 - 0x05 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c8, %c5) : (i4, i4) -> ()
+
+    // 0x08 - 0x06 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c8, %c6) : (i4, i4) -> ()
+
+    // 0x08 - 0x07 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c8, %c7) : (i4, i4) -> ()
+
+    // 0x08 - 0x08 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c8, %c8) : (i4, i4) -> ()
+
+    // 0x08 - 0x09 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c8, %c9) : (i4, i4) -> ()
+
+    // 0x08 - 0x0a = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c8, %c10) : (i4, i4) -> ()
+
+    // 0x08 - 0x0b = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c8, %c11) : (i4, i4) -> ()
+
+    // 0x08 - 0x0c = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c8, %c12) : (i4, i4) -> ()
+
+    // 0x08 - 0x0d = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c8, %c13) : (i4, i4) -> ()
+
+    // 0x08 - 0x0e = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c8, %c14) : (i4, i4) -> ()
+
+    // 0x08 - 0x0f = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c8, %c15) : (i4, i4) -> ()
+
+    // 0x09 - 0x00 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c9, %c0) : (i4, i4) -> ()
+
+    // 0x09 - 0x01 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c9, %c1) : (i4, i4) -> ()
+
+    // 0x09 - 0x02 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c9, %c2) : (i4, i4) -> ()
+
+    // 0x09 - 0x03 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c9, %c3) : (i4, i4) -> ()
+
+    // 0x09 - 0x04 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c9, %c4) : (i4, i4) -> ()
+
+    // 0x09 - 0x05 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c9, %c5) : (i4, i4) -> ()
+
+    // 0x09 - 0x06 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c9, %c6) : (i4, i4) -> ()
+
+    // 0x09 - 0x07 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c9, %c7) : (i4, i4) -> ()
+
+    // 0x09 - 0x08 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c9, %c8) : (i4, i4) -> ()
+
+    // 0x09 - 0x09 = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c9, %c9) : (i4, i4) -> ()
+
+    // 0x09 - 0x0a = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c9, %c10) : (i4, i4) -> ()
+
+    // 0x09 - 0x0b = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c9, %c11) : (i4, i4) -> ()
+
+    // 0x09 - 0x0c = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c9, %c12) : (i4, i4) -> ()
+
+    // 0x09 - 0x0d = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c9, %c13) : (i4, i4) -> ()
+
+    // 0x09 - 0x0e = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c9, %c14) : (i4, i4) -> ()
+
+    // 0x09 - 0x0f = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c9, %c15) : (i4, i4) -> ()
+
+    // 0x0a - 0x00 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c10, %c0) : (i4, i4) -> ()
+
+    // 0x0a - 0x01 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c10, %c1) : (i4, i4) -> ()
+
+    // 0x0a - 0x02 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c10, %c2) : (i4, i4) -> ()
+
+    // 0x0a - 0x03 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c10, %c3) : (i4, i4) -> ()
+
+    // 0x0a - 0x04 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c10, %c4) : (i4, i4) -> ()
+
+    // 0x0a - 0x05 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c10, %c5) : (i4, i4) -> ()
+
+    // 0x0a - 0x06 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c10, %c6) : (i4, i4) -> ()
+
+    // 0x0a - 0x07 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c10, %c7) : (i4, i4) -> ()
+
+    // 0x0a - 0x08 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c10, %c8) : (i4, i4) -> ()
+
+    // 0x0a - 0x09 = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c10, %c9) : (i4, i4) -> ()
+
+    // 0x0a - 0x0a = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c10, %c10) : (i4, i4) -> ()
+
+    // 0x0a - 0x0b = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c10, %c11) : (i4, i4) -> ()
+
+    // 0x0a - 0x0c = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c10, %c12) : (i4, i4) -> ()
+
+    // 0x0a - 0x0d = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c10, %c13) : (i4, i4) -> ()
+
+    // 0x0a - 0x0e = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c10, %c14) : (i4, i4) -> ()
+
+    // 0x0a - 0x0f = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c10, %c15) : (i4, i4) -> ()
+
+    // 0x0b - 0x00 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c11, %c0) : (i4, i4) -> ()
+
+    // 0x0b - 0x01 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c11, %c1) : (i4, i4) -> ()
+
+    // 0x0b - 0x02 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c11, %c2) : (i4, i4) -> ()
+
+    // 0x0b - 0x03 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c11, %c3) : (i4, i4) -> ()
+
+    // 0x0b - 0x04 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c11, %c4) : (i4, i4) -> ()
+
+    // 0x0b - 0x05 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c11, %c5) : (i4, i4) -> ()
+
+    // 0x0b - 0x06 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c11, %c6) : (i4, i4) -> ()
+
+    // 0x0b - 0x07 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c11, %c7) : (i4, i4) -> ()
+
+    // 0x0b - 0x08 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c11, %c8) : (i4, i4) -> ()
+
+    // 0x0b - 0x09 = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c11, %c9) : (i4, i4) -> ()
+
+    // 0x0b - 0x0a = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c11, %c10) : (i4, i4) -> ()
+
+    // 0x0b - 0x0b = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c11, %c11) : (i4, i4) -> ()
+
+    // 0x0b - 0x0c = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c11, %c12) : (i4, i4) -> ()
+
+    // 0x0b - 0x0d = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c11, %c13) : (i4, i4) -> ()
+
+    // 0x0b - 0x0e = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c11, %c14) : (i4, i4) -> ()
+
+    // 0x0b - 0x0f = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c11, %c15) : (i4, i4) -> ()
+
+    // 0x0c - 0x00 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c12, %c0) : (i4, i4) -> ()
+
+    // 0x0c - 0x01 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c12, %c1) : (i4, i4) -> ()
+
+    // 0x0c - 0x02 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c12, %c2) : (i4, i4) -> ()
+
+    // 0x0c - 0x03 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c12, %c3) : (i4, i4) -> ()
+
+    // 0x0c - 0x04 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c12, %c4) : (i4, i4) -> ()
+
+    // 0x0c - 0x05 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c12, %c5) : (i4, i4) -> ()
+
+    // 0x0c - 0x06 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c12, %c6) : (i4, i4) -> ()
+
+    // 0x0c - 0x07 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c12, %c7) : (i4, i4) -> ()
+
+    // 0x0c - 0x08 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c12, %c8) : (i4, i4) -> ()
+
+    // 0x0c - 0x09 = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c12, %c9) : (i4, i4) -> ()
+
+    // 0x0c - 0x0a = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c12, %c10) : (i4, i4) -> ()
+
+    // 0x0c - 0x0b = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c12, %c11) : (i4, i4) -> ()
+
+    // 0x0c - 0x0c = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c12, %c12) : (i4, i4) -> ()
+
+    // 0x0c - 0x0d = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c12, %c13) : (i4, i4) -> ()
+
+    // 0x0c - 0x0e = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c12, %c14) : (i4, i4) -> ()
+
+    // 0x0c - 0x0f = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c12, %c15) : (i4, i4) -> ()
+
+    // 0x0d - 0x00 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c13, %c0) : (i4, i4) -> ()
+
+    // 0x0d - 0x01 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c13, %c1) : (i4, i4) -> ()
+
+    // 0x0d - 0x02 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c13, %c2) : (i4, i4) -> ()
+
+    // 0x0d - 0x03 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c13, %c3) : (i4, i4) -> ()
+
+    // 0x0d - 0x04 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c13, %c4) : (i4, i4) -> ()
+
+    // 0x0d - 0x05 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c13, %c5) : (i4, i4) -> ()
+
+    // 0x0d - 0x06 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c13, %c6) : (i4, i4) -> ()
+
+    // 0x0d - 0x07 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c13, %c7) : (i4, i4) -> ()
+
+    // 0x0d - 0x08 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c13, %c8) : (i4, i4) -> ()
+
+    // 0x0d - 0x09 = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c13, %c9) : (i4, i4) -> ()
+
+    // 0x0d - 0x0a = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c13, %c10) : (i4, i4) -> ()
+
+    // 0x0d - 0x0b = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c13, %c11) : (i4, i4) -> ()
+
+    // 0x0d - 0x0c = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c13, %c12) : (i4, i4) -> ()
+
+    // 0x0d - 0x0d = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c13, %c13) : (i4, i4) -> ()
+
+    // 0x0d - 0x0e = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c13, %c14) : (i4, i4) -> ()
+
+    // 0x0d - 0x0f = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c13, %c15) : (i4, i4) -> ()
+
+    // 0x0e - 0x00 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c14, %c0) : (i4, i4) -> ()
+
+    // 0x0e - 0x01 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c14, %c1) : (i4, i4) -> ()
+
+    // 0x0e - 0x02 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c14, %c2) : (i4, i4) -> ()
+
+    // 0x0e - 0x03 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c14, %c3) : (i4, i4) -> ()
+
+    // 0x0e - 0x04 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c14, %c4) : (i4, i4) -> ()
+
+    // 0x0e - 0x05 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c14, %c5) : (i4, i4) -> ()
+
+    // 0x0e - 0x06 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c14, %c6) : (i4, i4) -> ()
+
+    // 0x0e - 0x07 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c14, %c7) : (i4, i4) -> ()
+
+    // 0x0e - 0x08 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c14, %c8) : (i4, i4) -> ()
+
+    // 0x0e - 0x09 = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c14, %c9) : (i4, i4) -> ()
+
+    // 0x0e - 0x0a = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c14, %c10) : (i4, i4) -> ()
+
+    // 0x0e - 0x0b = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c14, %c11) : (i4, i4) -> ()
+
+    // 0x0e - 0x0c = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c14, %c12) : (i4, i4) -> ()
+
+    // 0x0e - 0x0d = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c14, %c13) : (i4, i4) -> ()
+
+    // 0x0e - 0x0e = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c14, %c14) : (i4, i4) -> ()
+
+    // 0x0e - 0x0f = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c14, %c15) : (i4, i4) -> ()
+
+    // 0x0f - 0x00 = 0x0f
+    // CHECK: -1
+    func.call @check_sub(%c15, %c0) : (i4, i4) -> ()
+
+    // 0x0f - 0x01 = 0x0e
+    // CHECK: -2
+    func.call @check_sub(%c15, %c1) : (i4, i4) -> ()
+
+    // 0x0f - 0x02 = 0x0d
+    // CHECK: -3
+    func.call @check_sub(%c15, %c2) : (i4, i4) -> ()
+
+    // 0x0f - 0x03 = 0x0c
+    // CHECK: -4
+    func.call @check_sub(%c15, %c3) : (i4, i4) -> ()
+
+    // 0x0f - 0x04 = 0x0b
+    // CHECK: -5
+    func.call @check_sub(%c15, %c4) : (i4, i4) -> ()
+
+    // 0x0f - 0x05 = 0x0a
+    // CHECK: -6
+    func.call @check_sub(%c15, %c5) : (i4, i4) -> ()
+
+    // 0x0f - 0x06 = 0x09
+    // CHECK: -7
+    func.call @check_sub(%c15, %c6) : (i4, i4) -> ()
+
+    // 0x0f - 0x07 = 0x08
+    // CHECK: -8
+    func.call @check_sub(%c15, %c7) : (i4, i4) -> ()
+
+    // 0x0f - 0x08 = 0x07
+    // CHECK: 7
+    func.call @check_sub(%c15, %c8) : (i4, i4) -> ()
+
+    // 0x0f - 0x09 = 0x06
+    // CHECK: 6
+    func.call @check_sub(%c15, %c9) : (i4, i4) -> ()
+
+    // 0x0f - 0x0a = 0x05
+    // CHECK: 5
+    func.call @check_sub(%c15, %c10) : (i4, i4) -> ()
+
+    // 0x0f - 0x0b = 0x04
+    // CHECK: 4
+    func.call @check_sub(%c15, %c11) : (i4, i4) -> ()
+
+    // 0x0f - 0x0c = 0x03
+    // CHECK: 3
+    func.call @check_sub(%c15, %c12) : (i4, i4) -> ()
+
+    // 0x0f - 0x0d = 0x02
+    // CHECK: 2
+    func.call @check_sub(%c15, %c13) : (i4, i4) -> ()
+
+    // 0x0f - 0x0e = 0x01
+    // CHECK: 1
+    func.call @check_sub(%c15, %c14) : (i4, i4) -> ()
+
+    // 0x0f - 0x0f = 0x00
+    // CHECK: 0
+    func.call @check_sub(%c15, %c15) : (i4, i4) -> ()
 
     return
 }


### PR DESCRIPTION
This PR adds a `ccirc.sub` op that subtracts two wire bundles, mirroring the existing `ccirc.add`. Subtraction reuses the ripple-carry adder through two's complement (a - b = a + ~b + 1): synthSub inverts each bit of b and feeds fullAdderN a
  carry-in of 1 instead of 0, so no new gate logic is needed. It also extends the generated adder tests with an exhaustive 4-bit subtraction sweep and lowers cleanly through both the ccirc-to-func-arith and ccirc-to-xag passes.